### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,86 +14,123 @@ on:
 jobs:
   container:
     runs-on: ubuntu-latest
-    container: nextcloud
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v275
+      - name: Check actor permission
+        uses: skjnldsv/check-actor-permission@69e92a3c4711150929bca9fcf34448c5bf5526e7 # v3.0
         with:
-          path: gestion
+          require: write
 
-      - name: Create tar
+      - name: Set app env
         run: |
-          cd gestion && make appstore
+          # Split and keep last
+          echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
+          echo "APP_VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
-      - name: load app
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          path: ${{ env.APP_NAME }}
+
+      - name: Get app version number
+        id: app-version
+        uses: skjnldsv/xpath-action@f5b036e9d973f42c86324833fd00be90665fbf77 # master
+        with:
+          filename: ${{ env.APP_NAME }}/appinfo/info.xml
+          expression: "//info//version/text()"
+
+      - name: Validate app version against tag
         run: |
-          cd gestion
-          tar xzvf ./build/artifacts/appstore/gestion.tar.gz --directory /usr/src/nextcloud/apps/
+          [ "${{ env.APP_VERSION }}" = "${{ fromJSON(steps.app-version.outputs.result).version }}" ]
 
-      - name: Generate key
+      - name: Get appinfo data
+        id: appinfo
+        uses: skjnldsv/xpath-action@f5b036e9d973f42c86324833fd00be90665fbf77 # master
+        with:
+          filename: ${{ env.APP_NAME }}/appinfo/info.xml
+          expression: "//info//dependencies//nextcloud/@min-version"
+
+      - name: Get php version
+        id: php-versions
+        uses: icewind1991/nextcloud-version-matrix@58becf3b4bb6dc6cef677b15e2fd8e7d48c0908f # v1.3.1
+        with:
+          filename: ${{ env.APP_NAME }}/appinfo/info.xml
+
+      - name: Set up php ${{ steps.php-versions.outputs.php-min }}
+        uses: shivammathur/setup-php@cf4cade2721270509d5b1c766ab3549210a39a2a # v2.33.0
+        with:
+          php-version: ${{ steps.php-versions.outputs.php-min }}
+          coverage: none
         env:
-          APP_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-          APP_CRT: ${{ secrets.APP_CERTIFICATE }}
-        run: |
-          echo -n "$APP_KEY" > /usr/src/nextcloud/p.key
-          echo -n "$APP_CRT" > /usr/src/nextcloud/p.crt
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: sign app
-        env:
-          APP_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Package ${{ env.APP_NAME }} ${{ env.APP_VERSION }} with makefile
         run: |
-          cd /usr/src/nextcloud
-          php occ integrity:sign-app --privateKey=p.key --certificate=p.crt --path=/usr/src/nextcloud/apps/gestion
-          cd /usr/src/nextcloud/apps
-          tar cvzf gestion.tar.gz gestion
-          echo -n "$APP_KEY" > /usr/src/nextcloud/apps/p.key
-          openssl dgst -sha512 -sign /usr/src/nextcloud/apps/p.key /usr/src/nextcloud/apps/gestion.tar.gz | openssl base64 > /usr/src/nextcloud/apps/shasum.txt
+          cd ${{ env.APP_NAME }}
+          make appstore
+
+      - name: Checkout server ${{ fromJSON(steps.appinfo.outputs.result).nextcloud.min-version }}
+        continue-on-error: true
+        id: server-checkout
+        run: |
+          NCVERSION='${{ fromJSON(steps.appinfo.outputs.result).nextcloud.min-version }}'
+          wget --quiet https://download.nextcloud.com/server/releases/latest-$NCVERSION.zip
+          unzip latest-$NCVERSION.zip
+
+      - name: Checkout server master fallback
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        if: ${{ steps.server-checkout.outcome != 'success' }}
+        with:
+          persist-credentials: false
+          submodules: true
+          repository: nextcloud/server
+          path: nextcloud
+
+      - name: Sign app
+        run: |
+          # Extracting release
+          cd ${{ env.APP_NAME }}/build/artifacts/appstore
+          tar -xvf ${{ env.APP_NAME }}.tar.gz
+          cd ../../../../
+          # Setting up keys
+          echo '${{ secrets.APP_PRIVATE_KEY }}' > ${{ env.APP_NAME }}.key
+          wget --quiet "https://github.com/nextcloud/app-certificate-requests/raw/master/${{ env.APP_NAME }}/${{ env.APP_NAME }}.crt"
+          # Signing
+          php nextcloud/occ integrity:sign-app --privateKey=../${{ env.APP_NAME }}.key --certificate=../${{ env.APP_NAME }}.crt --path=../${{ env.APP_NAME }}/build/artifacts/appstore/${{ env.APP_NAME }}
+          # Rebuilding archive
+          cd ${{ env.APP_NAME }}/build/artifacts/appstore
+          tar -zcvf ${{ env.APP_NAME }}.tar.gz ${{ env.APP_NAME }}
+          openssl dgst -sha512 -sign ../../../../${{ env.APP_NAME }}.key ./${{ env.APP_NAME }}.tar.gz | openssl base64 > ./shasum.txt
           cat ./shasum.txt
 
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-
-      - name: Upload app tarball to release
-        uses: svenstaro/upload-release-action@v2
-        id: attach_to_release_app
+      - name: Attach tarball to github release
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # v2
+        id: attach_to_release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: /usr/src/nextcloud/apps/gestion.tar.gz
-          asset_name: gestion.tar.gz
-          tag: ${{ steps.get_version.outputs.VERSION }}
+          file: ${{ env.APP_NAME }}/build/artifacts/appstore/${{ env.APP_NAME }}.tar.gz
+          asset_name: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}.tar.gz
+          tag: ${{ env.APP_VERSION }}
           overwrite: true
 
       - name: Upload shasum to release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # v2
         id: attach_to_release_shasum
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: /usr/src/nextcloud/apps/shasum.txt
-          asset_name: shasum.${{ steps.get_version.outputs.VERSION }}.txt
-          tag: ${{ steps.get_version.outputs.VERSION }}
+          file: ${{ env.APP_NAME }}/build/artifacts/appstore/shasum.txt
+          asset_name: shasum.${{ env.APP_VERSION }}.txt
+          tag: ${{ env.APP_VERSION }}
           overwrite: true
 
-      - name: Sleep for 1 minute
-        run: sleep 60s
-        shell: bash
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: [container]
-    steps:
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-
       - name: Upload app to Nextcloud appstore
-        uses: R0Wi/nextcloud-appstore-push-action@v1
+        uses: nextcloud-releases/nextcloud-appstore-push-action@a011fe619bcf6e77ddebc96f9908e1af4071b9c1 # v1
         with:
-          app_name: gestion
+          app_name: ${{ env.APP_NAME }}
           appstore_token: ${{ secrets.APPSTORE_TOKEN }}
-          download_url: https://github.com/baimard/gestion/releases/download/${{ steps.get_version.outputs.VERSION }}/gestion.tar.gz
+          download_url: ${{ steps.attach_to_release.outputs.browser_download_url }}
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          nightly: false
 
       - name: Twitter
         uses: Eomm/why-don-t-you-tweet@v1

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ appstore:
 	--exclude="../$(app_name)/Makefile" \
 	--exclude="../$(app_name)/*.log" \
 	--exclude="../$(app_name)/phpunit*xml" \
+	--exclude="../$(app_name)/phpunit*.dist" \
 	--exclude="../$(app_name)/composer.*" \
 	--exclude="../$(app_name)/js/node_modules" \
 	--exclude="../$(app_name)/node_modules" \


### PR DESCRIPTION
Hello!

I have just a bit updated the release workflow.
Most changes are based on [Build and publish app release](https://github.com/nextcloud/.github/blob/master/workflow-templates/appstore-build-publish.yml) nextcloud workflow template.

### Changes
* **New signing flow**: download matching NC server, based on min-version support.
* **Pinned actions**: all third‑party actions now use immutable SHAs.
* **Version check**: new step to validate tag and `info.xml` version.
* **Edit Makefile**: add phpunix.xml.dist to excluded files.
* **Misc**: drop 60s sleep.

### Testing
* Workflow executed on my fork with a dummy private key: https://github.com/relisiuol/gestion/actions/runs/14559422426
* Last two steps (upload & tweet) were temporarily skipped for this test and commit history has been restored.

### Warning
* **Archive Name** : `tar` filename now uses version as suffix `gestion-${VERSION}.tar.gz`.

Best regards