### PR TITLE
Metadata - add donation link to appear directly on Nextcloud appstore

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -47,6 +47,7 @@ If you require adaptations of this application to comply with your country's reg
     <screenshot>https://raw.githubusercontent.com/baimard/gestion/master/tests/Unit/Panther/screens/produit.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/baimard/gestion/master/tests/Unit/Panther/screens/selectFolder.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/baimard/gestion/master/tests/Unit/Panther/screens/statistique.png</screenshot>
+    <donation>https://www.buymeacoffee.com/benjaminaimard</donation>
     <dependencies>
         <nextcloud min-version="30" max-version="31"/>
         <php min-version="8"/>


### PR DESCRIPTION
For better visibility to users (who will not visit github page)

For example of result see for example https://apps.nextcloud.com/apps/passwords (URL taken from funding.yaml - if you prefer https://github.com/sponsors/baimard instead, please modify accordingly)