### PR TITLE
Convert Factur-X user messages to English

### DIFF
--- a/src/js/modules/ajaxRequest.js
+++ b/src/js/modules/ajaxRequest.js
@@ -633,7 +633,7 @@ export function generateFacturXmlRequest(factureId, name, folder) {
     })
     .then(response => {
         if (!response.ok) {
-            return response.json().then(err => { throw new Error(err.message || 'Erreur serveur'); });
+            return response.json().then(err => { throw new Error(err.message || 'Server error'); });
         }
         return response.blob();
     })
@@ -644,10 +644,10 @@ export function generateFacturXmlRequest(factureId, name, folder) {
         a.download = name;
         a.click();
         window.URL.revokeObjectURL(url);
-        showMessage(t('gestion', 'Fichier XML Factur-X généré et sauvegardé.'));
+        showMessage(t('gestion', 'Factur-X XML file generated and saved.'));
     })
     .catch(error => {
-        showMessage(t('gestion', 'Erreur lors de la génération du XML : ') + error.message);
+        showMessage(t('gestion', 'Error generating the XML: ') + error.message);
         console.error(error);
     });
 };

--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -58,7 +58,7 @@ export function capture(afterCapturefunction) {
     })
   })
   .then(response => {
-    if (!response.ok) throw new Error("Erreur serveur");
+    if (!response.ok) throw new Error("Server error");
     return response.blob();
   })
   .then(blob => {


### PR DESCRIPTION
### Motivation
- Convert remaining Factur‑X user-facing messages and PDF/XML fallback server error texts from French to English so the UI messaging is consistent.

### Description
- Replaced French strings with English equivalents in `src/js/pdf.js` and `src/js/modules/ajaxRequest.js`, committed on branch `codex/issue-529`, and opened this draft PR targeting `master`.

### Testing
- Ran `node --check src/js/pdf.js` and `node --check src/js/modules/ajaxRequest.js`, which passed, and `git diff --check`, which passed; `npm run build` failed due to an external network fetch of Google Fonts returning HTTP 403; `npx eslint src/js/pdf.js src/js/modules/ajaxRequest.js` could not run because the repository does not include an ESLint flat config file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43ce71e3748332b7427ccb2eec81b5)