### PR TITLE
Refactor main listener into modular handler files and remove jQuery global

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "eslint-webpack-plugin": "^5.0.2",
     "file-loader": "^6.2.0",
     "html2canvas": "^1.4.1",
-    "jquery": "^3.7.1",
     "jspdf": "^4.2.1",
     "less": "^4.4.2",
     "less-loader": "^12.3.0",

--- a/src/js/listener/handlers/configuration_handlers.js
+++ b/src/js/listener/handlers/configuration_handlers.js
@@ -1,0 +1,48 @@
+import { getFilePickerBuilder } from "@nextcloud/dialogs";
+import { configuration, updateCurrentCompany, updateDBConfiguration } from "../../modules/ajaxRequest.js";
+import { path } from "../../modules/mainFunction.js";
+
+const chooseFolderLabel = t('gestion', 'Choose work folder');
+
+export function openAboutModal() {
+    const modal = document.getElementById("modalConfig");
+    if (modal) {
+        modal.style.display = "block";
+    }
+}
+
+export function closeModal(target) {
+    const modal = target.parentElement.parentElement;
+    modal.style.display = "none";
+}
+
+export function openFolderPicker() {
+    getFilePickerBuilder(chooseFolderLabel)
+        .allowDirectories(true)
+        .setMultiSelect(false)
+        .addButton({
+            label: t('gestion', 'Choose'),
+            callback: updateSelectedFolder,
+        })
+        .build()
+        .pick()
+        .catch(error => {
+            console.error("Erreur lors de l'ouverture du sélecteur :", error);
+        });
+}
+
+export function updateCurrentCompanySelection(target) {
+    updateCurrentCompany(target.value);
+}
+
+function updateSelectedFolder(nodes) {
+    const values = nodes.map(node => node.path);
+    const theFolder = document.getElementById('theFolder');
+    const table = theFolder.getAttribute('data-table');
+    const column = theFolder.getAttribute('data-column');
+    const id = theFolder.getAttribute('data-id');
+
+    updateDBConfiguration(table, column, values[0], id);
+    configuration(path);
+    document.getElementById('theFolder').value = values[0];
+}

--- a/src/js/listener/handlers/editable_handlers.js
+++ b/src/js/listener/handlers/editable_handlers.js
@@ -1,0 +1,65 @@
+import { updateEditable } from "../../modules/ajaxRequest.js";
+import { updateNumerical } from "../../modules/mainFunction.js";
+
+const EDITABLE_CLASSES = [
+    "editableNumber",
+    "editableNumeric",
+    "editableComment",
+    "editable",
+];
+
+const NON_INLINE_EDITABLE_CLASSES = [
+    "editableSelect",
+    "editableConfiguration",
+    "editableConfigurationSelect",
+];
+
+const IGNORED_SAVE_CLASSES = [
+    ...NON_INLINE_EDITABLE_CLASSES,
+    "editableComment",
+];
+
+export function isInlineEditable(element) {
+    return EDITABLE_CLASSES.some(className => element.classList.contains(className));
+}
+
+export function shouldSkipInlineEdit(element) {
+    return NON_INLINE_EDITABLE_CLASSES.some(className => element.classList.contains(className));
+}
+
+export function enableInlineEdit(element) {
+    element.setAttribute('contenteditable', 'true');
+    element.focus();
+}
+
+export function saveEditableElement(element, ignoreComment = false) {
+    const targetClass = element.className;
+
+    if (targetClass.includes("editableNumber") || targetClass.includes("editableNumeric")) {
+        const formatAsCurrency = element.dataset.column !== "quantite";
+        updateNumerical(element, formatAsCurrency);
+        return;
+    }
+
+    const ignoredClasses = ignoreComment ? IGNORED_SAVE_CLASSES : NON_INLINE_EDITABLE_CLASSES;
+
+    if (ignoredClasses.some(className => targetClass.includes(className))) {
+        return;
+    }
+
+    if (targetClass.includes("editable")) {
+        updateEditable(element);
+    }
+}
+
+export function applyMouseOverStyles(element) {
+    element.style.fontWeight = "bold";
+    element.addEventListener('mouseout', resetMouseOverStyles);
+}
+
+function resetMouseOverStyles(event) {
+    event.target.style.border = null;
+    event.target.style.padding = null;
+    event.target.style.fontWeight = null;
+    event.target.style.borderRadius = null;
+}

--- a/src/js/listener/handlers/product_handlers.js
+++ b/src/js/listener/handlers/product_handlers.js
@@ -1,0 +1,57 @@
+import { showError } from "@nextcloud/dialogs";
+import { baseUrl } from "../../modules/mainFunction.js";
+import { getProduitsById, listProduit, updateDB } from "../../modules/ajaxRequest.js";
+
+export function addProductToDevis() {
+    const devisId = document.getElementById('devisid').dataset.id;
+    const produitDevis = { id: devisId };
+
+    fetch(baseUrl + '/insertProduitDevis', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(produitDevis)
+    })
+        .then(function(response) {
+            if (response.ok) {
+                return response.json();
+            }
+            throw new Error('Network response was not ok.');
+        })
+        .then(function() {
+            getProduitsById();
+        })
+        .catch(function() {
+            showError(t('gestion', "Please create a new product"));
+        });
+}
+
+export function showProductSelect(target) {
+    const id = target.dataset.id;
+    const produitid = target.dataset.val;
+    target.textContent = "";
+    target.innerHTML = '<select id="listProduit">';
+    listProduit(document.getElementById('listProduit'), id, produitid);
+}
+
+export async function updateSelectedProduct(event) {
+    const option = event.target.options[event.target.selectedIndex];
+    const id = option.dataset.id;
+    const val = option.dataset.val;
+    const column = option.dataset.column;
+    const table = option.dataset.table;
+
+    await updateDB(table, column, val, id);
+
+    if (event.target.parentNode.className === 'selectableClient_devis') {
+        getClientByIdDevis(id);
+    }
+
+    if (event.target.id === 'listProduit') {
+        getProduitsById();
+    }
+
+    event.target.parentNode.textContent = event.target.value;
+    event.target.parentNode.dataset.val = id;
+}

--- a/src/js/listener/handlers/select_handlers.js
+++ b/src/js/listener/handlers/select_handlers.js
@@ -1,0 +1,24 @@
+import { updateDB } from "../../modules/ajaxRequest.js";
+
+export function updateLinkedListSelection(target) {
+    const myDiv = target.closest("div");
+    const id = myDiv.dataset.id;
+    const val = target.value;
+    const column = myDiv.dataset.column;
+    const table = myDiv.dataset.table;
+    target.setAttribute('data-current', target.value);
+    updateDB(table, column, val, id);
+}
+
+export function updateDateInput(target) {
+    updateDB(target.dataset.table, target.dataset.column, target.value, target.dataset.id);
+}
+
+export function updateEditableSelect(target) {
+    const table = target.getAttribute('data-table');
+    const column = target.getAttribute('data-column');
+    const value = target.value;
+    const id = target.getAttribute('data-id');
+
+    updateDB(table, column, value, id);
+}

--- a/src/js/listener/handlers/table_handlers.js
+++ b/src/js/listener/handlers/table_handlers.js
@@ -1,0 +1,53 @@
+import DataTable from 'datatables.net';
+import { duplicateDB, deleteDB, getProduitsById, drop } from "../../modules/ajaxRequest.js";
+import { Client } from '../../objects/client.js';
+import { Devis } from '../../objects/devis.js';
+import { Facture } from '../../objects/facture.js';
+import { Produit } from '../../objects/produit.js';
+
+const NEW_ITEM_HANDLERS = {
+    newClient: Client.newClient,
+    newDevis: Devis.newDevis,
+    newInvoice: Facture.newFacture,
+    newProduit: Produit.newProduct,
+};
+
+const RELOAD_HANDLERS = {
+    getProduitsById: () => getProduitsById(),
+    client: dt => Client.loadClientDT(dt),
+    devis: dt => Devis.loadDevisDT(dt),
+    facture: dt => Facture.loadFactureDT(dt),
+    produit: dt => Produit.loadProduitDT(dt),
+};
+
+export function handleNewItemClick(target) {
+    const handler = NEW_ITEM_HANDLERS[target.id];
+
+    if (!handler) {
+        return false;
+    }
+
+    handler(new DataTable('.tabledt'));
+    return true;
+}
+
+export function duplicateItem(target) {
+    duplicateDB(target.dataset.table, target.dataset.id, reloadDataTable, target.dataset.modifier);
+}
+
+export function deleteItem(target) {
+    deleteDB(target.dataset.table, target.dataset.id, reloadDataTable, target.dataset.modifier);
+}
+
+export function dropItem(target, direction) {
+    drop(target.dataset.id, reloadDataTable, target.dataset.modifier, direction);
+}
+
+function reloadDataTable(modifier) {
+    const dt = new DataTable('.tabledt');
+    const handler = RELOAD_HANDLERS[modifier];
+
+    if (handler) {
+        handler(dt);
+    }
+}

--- a/src/js/listener/main_listener.js
+++ b/src/js/listener/main_listener.js
@@ -1,307 +1,168 @@
-import { getFilePickerBuilder, showError } from "@nextcloud/dialogs";
-import { updateDB, configuration, updateEditable, duplicateDB, deleteDB, getProduitsById, updateCurrentCompany, updateDBConfiguration, listProduit, drop } from "../modules/ajaxRequest.js";
-import { path, baseUrl, updateNumerical } from "../modules/mainFunction.js";
-import DataTable from 'datatables.net';
 import { Client } from '../objects/client.js';
 import { Devis } from '../objects/devis.js';
-import { Facture } from '../objects/facture.js';
-import { Produit } from '../objects/produit.js';
+import {
+    applyMouseOverStyles,
+    enableInlineEdit,
+    isInlineEditable,
+    saveEditableElement,
+    shouldSkipInlineEdit,
+} from './handlers/editable_handlers.js';
+import {
+    closeModal,
+    openAboutModal,
+    openFolderPicker,
+    updateCurrentCompanySelection,
+} from './handlers/configuration_handlers.js';
+import {
+    deleteItem,
+    dropItem,
+    duplicateItem,
+    handleNewItemClick,
+} from './handlers/table_handlers.js';
+import {
+    addProductToDevis,
+    showProductSelect,
+    updateSelectedProduct,
+} from './handlers/product_handlers.js';
+import {
+    updateDateInput,
+    updateEditableSelect,
+    updateLinkedListSelection,
+} from './handlers/select_handlers.js';
 
-var choose_folder = t('gestion', 'Choose work folder');
-document.addEventListener('DOMContentLoaded', function () {
+let lastKeyEventTime = 0;
 
-    document.body.addEventListener('click', function (event) {
+const HOVERABLE_CLASSES = ["editable", "loadSelect", "selectable"];
 
-        if (event.target && event.target.id === 'about') {
-            var modal = document.getElementById("modalConfig");
-            if (modal) {
-                modal.style.display = "block";
-            }
-        }
+function registerMainListeners() {
+    document.body.addEventListener('click', handleBodyClick);
+    document.body.addEventListener('dblclick', handleBodyDoubleClick);
+    document.body.addEventListener('change', handleBodyChange);
+    document.body.addEventListener('keydown', handleBodyKeydown);
+    document.body.addEventListener('focusout', handleBodyFocusout);
+    document.body.addEventListener('mouseover', handleBodyMouseover);
+}
 
-        if (event.target && event.target.id === 'theFolder') {
-            getFilePickerBuilder(choose_folder)
-                .allowDirectories(true)
-                .setMultiSelect(false)
-                .addButton({
-                    label: t('gestion', 'Choose'),
-                    callback: (nodes) => {
-                        // Get the values of the picked nodes
-                        const values = nodes.map(node => node.path);
-                        var theFolder = document.getElementById('theFolder');
-                        var table = theFolder.getAttribute('data-table');
-                        var column = theFolder.getAttribute('data-column');
-                        var id = theFolder.getAttribute('data-id');
-                        
-                        updateDBConfiguration(table, column, values[0], id);
-                        configuration(path);
-                        document.getElementById('theFolder').value = values[0];
-                    },
-                })
-                .build()
-                .pick()
-                .catch(error => {
-                    console.error("Erreur lors de l'ouverture du sélecteur :", error);
-                });
-        }
+function handleBodyClick(event) {
+    const target = event.target;
 
-        if (
-            event.target.classList.contains("editableSelect") ||
-            event.target.classList.contains("editableConfiguration") ||
-            event.target.classList.contains("editableConfigurationSelect")
-        ) {
-            // Empêcher le comportement par défaut
-        } else {
-            if (
-                event.target.classList.contains("editableNumber") ||
-                event.target.classList.contains("editableNumeric") ||
-                event.target.classList.contains("editableComment") ||
-                event.target.classList.contains("editable")
-            ) {
-                event.target.setAttribute('contenteditable', 'true');
-                event.target.focus();
-            } else if (event.target.classList.contains("loadSelect_listclient")) {
-                Client.loadClientList_cid(event);
-            } else if (event.target.classList.contains("loadSelect_listdevis")) {
-                Devis.loadDevisList_dnum(event);
-            } else {
-                switch (event.target.id) {
-                    case "newClient":
-                        Client.newClient(new DataTable('.tabledt'));
-                        break;
-                    case "newDevis":
-                        Devis.newDevis(new DataTable('.tabledt'));
-                        break;
-                    case "newInvoice":
-                        Facture.newFacture(new DataTable('.tabledt'));
-                        break;
-                    case "newProduit":
-                        Produit.newProduct(new DataTable('.tabledt'));
-                        break;
-                    default:
-                        // Gérer les autres cas si nécessaire
-                        break;
-                }
-            }
-        }
-        
-        if (event.target.classList.contains('menu')) {
-            var menuId = event.target.dataset.menu;
-            var menu = document.getElementById('menu-' + menuId);
-            menu.classList.toggle('open');
-        }
+    if (target && target.id === 'about') {
+        openAboutModal();
+    }
 
-        if (event.target.classList.contains('modalClose')) {
-            var modal = event.target.parentElement.parentElement;
-            modal.style.display = "none";
-        }
+    if (target && target.id === 'theFolder') {
+        openFolderPicker();
+    }
 
-        if (event.target.classList.contains('duplicateItem')) {
-            var id = event.target.dataset.id;
-            var table = event.target.dataset.table;
-            var modifier = event.target.dataset.modifier;
-            duplicateDB(table, id, reloadDataTable, modifier);
-        }
+    handleEditableOrCreationClick(event);
 
-        if (event.target.classList.contains('drop_down')) {
-            var id = event.target.dataset.id;
-            var modifier = event.target.dataset.modifier;
-            drop(id, reloadDataTable, modifier, 'down');
-        }
+    if (target.classList.contains('menu')) {
+        const menu = document.getElementById('menu-' + target.dataset.menu);
+        menu.classList.toggle('open');
+    }
 
-        if (event.target.classList.contains('drop_up')) {
-            var id = event.target.dataset.id;
-            var modifier = event.target.dataset.modifier;
-            drop(id, reloadDataTable, modifier, 'up');
-        }
+    if (target.classList.contains('modalClose')) {
+        closeModal(target);
+    }
 
-        if (event.target.classList.contains('deleteItem')) {
-            var id = event.target.dataset.id;
-            var table = event.target.dataset.table;
-            var modifier = event.target.dataset.modifier;
-            deleteDB(table, id, reloadDataTable, modifier);
-        }
+    if (target.classList.contains('duplicateItem')) {
+        duplicateItem(target);
+    }
 
-        if (event.target.id === 'devisAdd') {
-            var devis_id = document.getElementById('devisid').dataset.id;
-            var produit_devis = {
-                id: devis_id
-            };
+    if (target.classList.contains('drop_down')) {
+        dropItem(target, 'down');
+    }
 
-            fetch(baseUrl + '/insertProduitDevis', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(produit_devis)
-            })
-            .then(function(response) {
-                if (response.ok) {
-                    return response.json();
-                } else {
-                    throw new Error('Network response was not ok.');
-                }
-            })
-            .then(function() {
-                getProduitsById();
-            })
-            .catch(function() {
-                showError(t('gestion', "Please create a new product"));
-            });
-        }
+    if (target.classList.contains('drop_up')) {
+        dropItem(target, 'up');
+    }
 
-    });
+    if (target.classList.contains('deleteItem')) {
+        deleteItem(target);
+    }
 
-    document.body.addEventListener('dblclick', function(event) {
-        if (event.target.classList.contains('selectable')) {
-            var id = event.target.dataset.id;
-            var produitid = event.target.dataset.val;
-            event.target.textContent = "";
-            event.target.innerHTML = '<select id="listProduit">';
-            listProduit(document.getElementById('listProduit'), id, produitid);
-        }
-    });
+    if (target.id === 'devisAdd') {
+        addProductToDevis();
+    }
+}
 
-    document.body.addEventListener('change', function(event) {
-        if (event.target.classList.contains('listClient') || event.target.classList.contains('listDevis')) {
-            var myDiv = event.target.closest("div");
-            var id = myDiv.dataset.id;
-            var val = event.target.value;
-            var column = myDiv.dataset.column;
-            var table = myDiv.dataset.table;
-            event.target.setAttribute('data-current', event.target.value);
-            updateDB(table, column, val, id);
-        }
+function handleEditableOrCreationClick(event) {
+    const target = event.target;
 
-        if (event.target.classList.contains('inputDate')) {
-            var id = event.target.dataset.id;
-            var val = event.target.value;
-            var column = event.target.dataset.column;
-            var table = event.target.dataset.table;
-            updateDB(table, column, val, id);
-        }
-
-        if (event.target.id === 'listProduit' || event.target.id === 'listDevis') {
-            waitforUpdateProduits(event, table, column, val, id)
-        }
-
-        if (event.target.classList.contains('editableSelect')) {
-            var table = event.target.getAttribute('data-table');
-            var column = event.target.getAttribute('data-column');
-            var value = event.target.value;
-            var id = event.target.getAttribute('data-id');
-            
-            updateDB(table, column, value, id);
-        }
-
-        if(event.target.id === "CurrentCompany-select"){
-            var value = event.target.value;
-            updateCurrentCompany(value);
-        }
-    });
-
-    var lastKeyEventTime = 0;
-
-    document.body.addEventListener('keydown', function(e) {
-        if (e.key === "Enter") {
-
-            lastKeyEventTime = Date.now();
-
-            var targetClass = e.target.className;
-
-            if (targetClass.includes("editableNumber") || targetClass.includes("editableNumeric")) {
-
-                const formatAsCurrency =
-                    e.target.dataset.column !== "quantite";
-
-                updateNumerical(e.target, formatAsCurrency);
-
-            } else if (
-                targetClass.includes("editableSelect") ||
-                targetClass.includes("editableConfiguration") ||
-                targetClass.includes("editableConfigurationSelect") ||
-                targetClass.includes("editableComment")
-            ) {
-
-                // Empêcher le comportement par défaut
-
-            } else if (targetClass.includes("editable")) {
-
-                updateEditable(e.target);
-            }
-        }
-    });
-
-    document.body.addEventListener('focusout', function(e) {
-    if (Date.now() - lastKeyEventTime < 100) {
-        e.preventDefault();
+    if (shouldSkipInlineEdit(target)) {
         return;
     }
 
-    var targetClass = e.target.className;
-
-    if (targetClass.includes("editableNumber") || targetClass.includes("editableNumeric")) {
-
-        const formatAsCurrency =
-            e.target.dataset.column !== "quantite";
-
-        updateNumerical(e.target, formatAsCurrency);
-
-    } else if (
-        targetClass.includes("editableSelect") ||
-        targetClass.includes("editableConfiguration") ||
-        targetClass.includes("editableConfigurationSelect")
-    ) {
-    } else if (targetClass.includes("editable")) {
-
-        updateEditable(e.target);
-    }
-});
-
-
-    document.body.addEventListener('mouseover', function(event) {
-        if(event.target.classList.contains("editable") || event.target.classList.contains("loadSelect") || event.target.classList.contains("selectable")){
-            applyMouseOverStyles(event.target);
-        }
-    });
-
-    function applyMouseOverStyles(element) {
-        element.style.fontWeight = "bold";
-        element.addEventListener('mouseout', function(e) {
-            e.target.style.border = null;
-            e.target.style.padding = null;
-            e.target.style.fontWeight = null;
-            e.target.style.borderRadius = null;
-        });
+    if (isInlineEditable(target)) {
+        enableInlineEdit(target);
+        return;
     }
 
-    function reloadDataTable(modifier) {
-        var dt = new DataTable('.tabledt');
-        if (modifier === "getProduitsById") { getProduitsById(); }
-        if (modifier === "client") { Client.loadClientDT(dt); }
-        if (modifier === "devis") { Devis.loadDevisDT(dt); }
-        if (modifier === "facture") { Facture.loadFactureDT(dt); }
-        if (modifier === "produit") { Produit.loadProduitDT(dt); }
+    if (target.classList.contains("loadSelect_listclient")) {
+        Client.loadClientList_cid(event);
+        return;
     }
 
-    async function waitforUpdateProduits(event, table, column, val, id){
-
-        var id = event.target.options[event.target.selectedIndex].dataset.id;
-        var val = event.target.options[event.target.selectedIndex].dataset.val;
-        var column = event.target.options[event.target.selectedIndex].dataset.column;
-        var table = event.target.options[event.target.selectedIndex].dataset.table;
-
-        await updateDB(table, column, val, id);
-
-        if (event.target.parentNode.className === 'selectableClient_devis') {
-            getClientByIdDevis(id);
-        }
-
-        if (event.target.id === 'listProduit') {
-            getProduitsById();
-        }
-
-        event.target.parentNode.textContent = event.target.value;
-        event.target.parentNode.dataset.val = id;
+    if (target.classList.contains("loadSelect_listdevis")) {
+        Devis.loadDevisList_dnum(event);
+        return;
     }
-});
+
+    handleNewItemClick(target);
+}
+
+function handleBodyDoubleClick(event) {
+    if (event.target.classList.contains('selectable')) {
+        showProductSelect(event.target);
+    }
+}
+
+function handleBodyChange(event) {
+    const target = event.target;
+
+    if (target.classList.contains('listClient') || target.classList.contains('listDevis')) {
+        updateLinkedListSelection(target);
+    }
+
+    if (target.classList.contains('inputDate')) {
+        updateDateInput(target);
+    }
+
+    if (target.id === 'listProduit' || target.id === 'listDevis') {
+        updateSelectedProduct(event);
+    }
+
+    if (target.classList.contains('editableSelect')) {
+        updateEditableSelect(target);
+    }
+
+    if (target.id === "CurrentCompany-select") {
+        updateCurrentCompanySelection(target);
+    }
+}
+
+function handleBodyKeydown(event) {
+    if (event.key !== "Enter") {
+        return;
+    }
+
+    lastKeyEventTime = Date.now();
+    saveEditableElement(event.target, true);
+}
+
+function handleBodyFocusout(event) {
+    if (Date.now() - lastKeyEventTime < 100) {
+        event.preventDefault();
+        return;
+    }
+
+    saveEditableElement(event.target);
+}
+
+function handleBodyMouseover(event) {
+    if (HOVERABLE_CLASSES.some(className => event.target.classList.contains(className))) {
+        applyMouseOverStyles(event.target);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', registerMainListeners);

--- a/webpack.js
+++ b/webpack.js
@@ -31,12 +31,6 @@ module.exports =
       new webpack.DefinePlugin({
         'process.platform': JSON.stringify('browser') // or 'win32' if you need to simulate Windows
       }),
-      new webpack.ProvidePlugin({
-           $: 'jquery',
-           jQuery: 'jquery',
-           "window.jQuery": "jquery",
-           jquery: 'jquery'
-       }),
      ],
     resolve: {
       fallback: {


### PR DESCRIPTION
### Motivation

- Improve maintainability by splitting the large `main_listener.js` into focused handler modules for configuration, editable elements, products, selects and table actions.
- Remove the implicit global jQuery injection to reduce dependency surface and avoid relying on provided globals from webpack.

### Description

- Added new handler modules: `src/js/listener/handlers/configuration_handlers.js`, `editable_handlers.js`, `product_handlers.js`, `select_handlers.js`, and `table_handlers.js` implementing focused event handling logic and utility functions such as `openFolderPicker`, `saveEditableElement`, `duplicateItem`, and `updateLinkedListSelection`.
- Rewrote `src/js/listener/main_listener.js` to import and wire the new handlers, register granular event listeners (`click`, `dblclick`, `change`, `keydown`, `focusout`, `mouseover`) and consolidate logic into small functions like `handleBodyClick`, `handleBodyChange`, and `handleBodyKeydown`.
- Removed `jquery` from `devDependencies` in `package.json` and eliminated the `webpack.ProvidePlugin` that injected jQuery globals from `webpack.js` to stop using implicit global jQuery.

### Testing

- Ran a webpack build using the existing config (`webpack --config webpack.js`) and the build completed without errors.
- No automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43d53cb47c8332ac21782e46ca66c6)