### PR TITLE
Draft: Remove jQuery usage from src JavaScript

### DIFF
--- a/src/js/devisShow.js
+++ b/src/js/devisShow.js
@@ -10,7 +10,7 @@ import { capture, sendMail } from "./pdf";
 window.addEventListener("DOMContentLoaded", function () {
     globalConfiguration();
 
-    Client.getClientByIdDevis($("#devisid").data("id"));
+    Client.getClientByIdDevis(document.getElementById("devisid").dataset.id);
     getProduitsById();
 
     var pdf = document.getElementById("pdf");

--- a/src/js/factureShow.js
+++ b/src/js/factureShow.js
@@ -11,7 +11,7 @@ import { capture, captureFacturX, captureFacturXml, sendFacturXToIopole, sendMai
 window.addEventListener("DOMContentLoaded", function () {
     globalConfiguration();
 
-    Client.getClientByIdDevis($("#devisid").data("id"));
+    Client.getClientByIdDevis(document.getElementById("devisid").dataset.id);
     getProduitsById();
 
     // Bouton 1 — Sauvegarder dans Nextcloud (pdf)

--- a/src/js/modules/ajaxRequest.js
+++ b/src/js/modules/ajaxRequest.js
@@ -297,32 +297,42 @@ export function getStats() {
  * @param {*} f1 
  */
 export function configuration(f1) {
-    $.ajax({
-        url: baseUrl + '/getConfiguration',
-        type: 'PROPFIND',
-        contentType: 'application/json',
-        async: false,
-    }).done(function (response) {
-        f1(response);
-    }).fail(function (response, code) {
-        showError(response);
-    });
+    const request = new XMLHttpRequest();
+    request.open('PROPFIND', baseUrl + '/getConfiguration', false);
+    request.setRequestHeader('Content-Type', 'application/json');
+    request.onload = function () {
+        if (request.status >= 200 && request.status < 300) {
+            f1(request.responseText);
+        } else {
+            showError(request.responseText);
+        }
+    };
+    request.onerror = function () {
+        showError(request.responseText);
+    };
+    request.send();
 }
 
 /**
  * 
  */
 export function isconfig() {
-    $.ajax({
-        url: baseUrl + '/isconfig',
-        type: 'GET',
-        contentType: 'application/json'
-    }).done(function (response) {
+    fetch(baseUrl + '/isconfig', {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    })
+    .then(response => response.json())
+    .then(response => {
         if (!response) {
             var modal = document.getElementById("modalConfig");
             modal.style.display = "block";
         }
     })
+    .catch(error => {
+        showError(error);
+    });
 }
 
 /**
@@ -611,7 +621,9 @@ export function saveNextcloud(myData) {
     })
     .then(response => {
         if (response.ok) {
-            showMessage(t('gestion', 'Save in') + " " + $("#theFolder").val() + "/" + $("#pdf").data("folder"));
+            const folder = document.getElementById("theFolder").value;
+            const pdfFolder = document.getElementById("pdf").dataset.folder;
+            showMessage(t('gestion', 'Save in') + " " + folder + "/" + pdfFolder);
         } else {
             throw new Error('There is an error');
         }

--- a/src/js/modules/mainFunction.js
+++ b/src/js/modules/mainFunction.js
@@ -50,14 +50,18 @@ export function globalConfiguration(checkConfig=true){
  * 
  */
 export function configureDT() {
-    $('.editable').attr('title', t('gestion', 'Editable (Click to change)'));
+    document.querySelectorAll('.editable').forEach(element => {
+        element.setAttribute('title', t('gestion', 'Editable (Click to change)'));
+    });
 }
 
 /**
  * 
  */
 export function configureShow() {
-    $('.sendmail').attr('title', t('gestion', 'Your global Nextcloud mail server need to be configured'));
+    document.querySelectorAll('.sendmail').forEach(element => {
+        element.setAttribute('title', t('gestion', 'Your global Nextcloud mail server need to be configured'));
+    });
 }
 
 /**
@@ -72,13 +76,14 @@ export function showDone() {
  * @param {*} el 
  */
 export function checkSelect(el) {
-    $(el).each(function (arrayID, elem) {
-        $(elem).find('option').each(function () {
-            if (this.value == elem.getAttribute("data-current")) {
-                $(this).prop('selected', true)
+    const elements = el instanceof Element ? [el] : Array.from(el);
+    elements.forEach(elem => {
+        elem.querySelectorAll('option').forEach(option => {
+            if (option.value == elem.getAttribute("data-current")) {
+                option.selected = true;
             }
-        })
-    })
+        });
+    });
 }
 
 
@@ -98,7 +103,7 @@ export function checkSelectPurJs(el) {
  */
 export function LoadDT(DT, response, cls) {
     DT.clear();
-    $.each(JSON.parse(response), function (arrayID, myresp) {
+    JSON.parse(response).forEach(myresp => {
         let c = new cls(myresp);
         DT.row.add(c.getDTRow());
     });
@@ -153,8 +158,9 @@ export function modifyCell(r, positionColumn = -1, data){
  */
  export function path(res) {
     var myres = JSON.parse(res)[0];
-    $("#theFolder").val(myres.path);
-    $("#theFolder").attr('data-id', myres.id);
+    const folder = document.getElementById("theFolder");
+    folder.value = myres.path;
+    folder.setAttribute('data-id', myres.id);
 };
 
 
@@ -207,8 +213,10 @@ fetch(url, options)
 export function checkAutoIncrement(response){
     var myresp = JSON.parse(response)[0];
     if(myresp.auto_invoice_number==1){
-        $('.deleteItem').remove();
-        $(".factureNum").removeClass("editable");
+        document.querySelectorAll('.deleteItem').forEach(element => element.remove());
+        document.querySelectorAll(".factureNum").forEach(element => {
+            element.classList.remove("editable");
+        });
     }
 }
 


### PR DESCRIPTION
### Motivation
- Supprimer toutes les références à jQuery dans le répertoire `src` et migrer le code vers du JavaScript natif pour réduire la dépendance à jQuery tout en préservant le comportement existant.

### Description
- Remplacement des sélecteurs, attributs, itérations, gestion des classes et accès `data-*` jQuery par des API DOM natives (`document.querySelectorAll`, `document.getElementById`, `dataset`, `classList`, `setAttribute`, `forEach`).
- Remplacement des appels `$.ajax` par `XMLHttpRequest` (pour préserver le comportement synchrone de `PROPFIND`) et `fetch` pour les requêtes asynchrones dans `src/js/modules/ajaxRequest.js`.
- Mise à jour des vues pour récupérer les `data` et attacher les gestionnaires d'événements avec les APIs natives (ex. `document.getElementById("devisid").dataset.id` et lecture de `#theFolder` via `value`/`dataset`).
- Fichiers modifiés : `src/js/modules/mainFunction.js`, `src/js/modules/ajaxRequest.js`, `src/js/factureShow.js`, `src/js/devisShow.js`.

### Testing
- Exécution de la recherche `rg -n "\$\.|\$\(|jQuery|jquery" src` pour vérifier l'absence de références à jQuery dans `src`, qui a rapporté aucun usage restant.
- Lancement de la construction `npm run build` (webpack) qui a échoué à cause d'une ressource externe bloquée : l'`@import` Google Fonts dans `src/css/mycss.less` retourne `Forbidden` dans cet environnement, la compilation a donc été interrompue avant une vérification complète des assets.
- Aucun autre test automatisé n'a été exécuté dans le cadre de cette modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fb78556388332b9a49af4a8936d90)