### PR TITLE
Fix zip_code length handling and normalize existing values

### DIFF
--- a/lib/Db/Bdd.php
+++ b/lib/Db/Bdd.php
@@ -221,6 +221,7 @@ class Bdd {
             $safeData = strip_tags($data, '<br>');
             $safeData = html_entity_decode($safeData, ENT_QUOTES, 'UTF-8');
             $safeData = rtrim($safeData);
+            $safeData = $this->normalizeColumnData($column, $safeData);
 
             $sql = "UPDATE " . $this->tableprefix . $table . " SET $column = ? WHERE `id` = ? AND `id_configuration` = ?";
             $this->execSQLNoData($sql, array($safeData, $id, $id_configuration));
@@ -228,7 +229,7 @@ class Bdd {
             return true;
         }
         return false;
-}
+    }
 
 
     /**
@@ -236,8 +237,9 @@ class Bdd {
      */
     public function gestion_update_configuration($table, $column, $data, $id, $idNextcloud){
         if(in_array($table, $this->whiteTable, true) && in_array($column, $this->whiteColumn, true)){
+            $safeData = $this->normalizeColumnData($column, htmlentities(rtrim($data)));
             $sql = "UPDATE ".$this->tableprefix.$table." SET $column = ? WHERE `id` = ? AND `id_nextcloud` = ?";
-            $this->execSQLNoData($sql, array(htmlentities(rtrim($data)), $id, $idNextcloud));
+            $this->execSQLNoData($sql, array($safeData, $id, $idNextcloud));
             return true;
         }
         return false;
@@ -249,11 +251,25 @@ class Bdd {
      */
     public function gestion_updateConfiguration($table, $column, $data, $id){
         if(in_array($table, $this->whiteTable, true) && in_array($column, $this->whiteColumn, true)){
+            $safeData = $this->normalizeColumnData($column, htmlentities(rtrim($data)));
             $sql = "UPDATE ".$this->tableprefix.$table." SET $column = ? WHERE `id` = ?";
-            $this->execSQLNoData($sql, array(htmlentities(rtrim($data)), $id));
+            $this->execSQLNoData($sql, array($safeData, $id));
             return true;
         }
         return false;
+    }
+
+
+    private function normalizeColumnData($column, $data){
+        if ($column === 'zip_code') {
+            return substr($data, 0, 20);
+        }
+
+        if ($column === 'country_code') {
+            return substr($data, 0, 5);
+        }
+
+        return $data;
     }
 
     /**
@@ -372,7 +388,7 @@ class Bdd {
                                      $this->l->t('INVOICE'),
                                      $this->l->t('Your company vat number'),
                                      $this->l->t('Your company city name'),
-                                     $this->l->t('Your company zip code'))); 
+                                     ''));
     return true; }
 
     public function deleteCompany($idCompany, $idNextcloud){

--- a/lib/Migration/Version20006Date20260721120000.php
+++ b/lib/Migration/Version20006Date20260721120000.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Gestion\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version20006Date20260721120000 extends SimpleMigrationStep {
+
+	private IDBConnection $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		return $schemaClosure();
+	}
+
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$this->normalizeZipCode('gestion_configuration');
+		$this->normalizeZipCode('gestion_client');
+
+		$output->info('Zip codes successfully normalized.');
+	}
+
+	private function normalizeZipCode(string $table): void {
+		$select = $this->connection->getQueryBuilder();
+		$select->select('id', 'zip_code')
+			->from($table);
+
+		$cursor = $select->executeQuery();
+		while ($row = $cursor->fetch()) {
+			$currentZipCode = $row['zip_code'];
+			$zipCode = substr($currentZipCode ?? '', 0, 20);
+			if ($currentZipCode !== null && $zipCode === $currentZipCode) {
+				continue;
+			}
+
+			$update = $this->connection->getQueryBuilder();
+			$update->update($table)
+				->set('zip_code', $update->createNamedParameter($zipCode))
+				->where($update->expr()->eq('id', $update->createNamedParameter($row['id'])))
+				->executeStatement();
+		}
+		$cursor->closeCursor();
+	}
+}


### PR DESCRIPTION
### Motivation
- A DB schema change introduced a `zip_code` column limited to 20 characters and existing rows with longer or NULL values can cause MySQL errors (`Data too long for column 'zip_code'`) and block users. 
- Prevent runtime exceptions after migration by normalizing existing data and ensuring all code paths clamp values before writing to the database. 

### Description
- Add a post-schema migration `lib/Migration/Version20006Date20260721120000.php` that iterates `gestion_configuration` and `gestion_client`, truncates `zip_code` to 20 characters and replaces problematic values to avoid DB errors. 
- Add `normalizeColumnData()` to `lib/Db/Bdd.php` and call it from update helpers to clamp `zip_code` to 20 characters and `country_code` to 5 characters before writes. 
- Change the `createCompany()` default to store an empty `zip_code` instead of a translated placeholder to avoid inserting strings longer than the column. 
- Prepare this work as a draft change (follow-up should be applied on a `codex/issue-<number>` branch and opened as a draft PR against `master`). 

### Testing
- `php -l lib/Db/Bdd.php` succeeded for syntax checks. 
- `php -l lib/Migration/Version20006Date20260721120000.php` succeeded for syntax checks. 
- `git diff --check` reported no remaining whitespace or diff issues. 
- `vendor/bin/phpunit --colors=always --testdox` could not be run because vendor dependencies are not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fbbb81fcc8332b16756790827790d)