### PR TITLE
Fix configuration currency parsing

### DIFF
--- a/src/js/configuration.js
+++ b/src/js/configuration.js
@@ -2,7 +2,7 @@
 import "../css/mycss.less";
 
 import { addShareUser, configuration, createCompany, deleteCompany, delShareUser, updateDBConfiguration} from "./modules/ajaxRequest.js";
-import { globalConfiguration } from "./modules/mainFunction.js";
+import { globalConfiguration, parseConfigurationResponse } from "./modules/mainFunction.js";
 import "./listener/main_listener";
 import { getAutoIncrement, setCurrencyList, setFormatList } from "./modules/list.js";
 
@@ -108,8 +108,8 @@ function safeValue(value) {
 
 function loadConfigurationDT(response) {
 
-    // Parse the JSON response
-    const data = JSON.parse(response);
+    // Parse the JSON response and ensure the table only receives an array.
+    const data = parseConfigurationResponse(response);
 
     // Iterate over each item in the parsed JSON array
     data.forEach(function (myresp) {

--- a/src/js/modules/mainFunction.js
+++ b/src/js/modules/mainFunction.js
@@ -4,6 +4,47 @@ import { configuration, getStats, isconfig, updateEditable } from "./ajaxRequest
 import { generateUrl } from "@nextcloud/router";
 export var baseUrl = generateUrl('/apps/gestion');
 export var cur = null;
+export const defaultCurrencyCode = 'EUR';
+export const defaultCurrencyLocale = 'en-EN';
+
+/**
+ * Parse configuration responses that can be returned either as an array,
+ * a JSON-encoded array, or a JSON-encoded string containing the array.
+ *
+ * @param {*} response
+ * @return {Array}
+ */
+export function parseConfigurationResponse(response) {
+    try {
+        let data = response;
+
+        if (typeof data === 'string') {
+            data = JSON.parse(data);
+        }
+
+        if (typeof data === 'string') {
+            data = JSON.parse(data);
+        }
+
+        return Array.isArray(data) ? data : [];
+    } catch (error) {
+        return [];
+    }
+}
+
+/**
+ * Return a valid ISO 4217 currency code for Intl.NumberFormat.
+ *
+ * @param {*} currencyCode
+ * @return {string}
+ */
+function normalizeCurrencyCode(currencyCode) {
+    if (typeof currencyCode !== 'string' || currencyCode.trim() === '') {
+        return defaultCurrencyCode;
+    }
+
+    return currencyCode.trim().toUpperCase();
+}
 
 /**
  * 
@@ -169,11 +210,14 @@ export function modifyCell(r, positionColumn = -1, data){
  * @param {*} response 
  */
 export function getCurrency(response) {
+    const myresp = parseConfigurationResponse(response)[0] || {};
+    const locale = myresp.format || defaultCurrencyLocale;
+    const currency = normalizeCurrencyCode(myresp.devise);
+
     try {
-        var myresp = JSON.parse(response)[0];
-        cur = new Intl.NumberFormat(myresp.format, { style: 'currency', currency: myresp.devise, minimumFractionDigits: 2 });
+        cur = new Intl.NumberFormat(locale, { style: 'currency', currency: currency, minimumFractionDigits: 2 });
     } catch (error) {
-        cur = new Intl.NumberFormat("en-EN", { style: 'currency', currency: myresp.devise, minimumFractionDigits: 2 });
+        cur = new Intl.NumberFormat(defaultCurrencyLocale, { style: 'currency', currency: defaultCurrencyCode, minimumFractionDigits: 2 });
     }
 }
 


### PR DESCRIPTION
### Motivation
- Corriger deux erreurs runtime observées dans la configuration : `Currency code is required with currency style` et `data.forEach is not a function` causées par des réponses de configuration inattendues ou des champs `devise`/`format` manquants.

### Description
- Ajout d’une fonction `parseConfigurationResponse` dans `src/js/modules/mainFunction.js` qui normalise les réponses de configuration (tableau, JSON encodé ou chaîne encodée) et retourne toujours un tableau sûr.
- Ajout de `defaultCurrencyCode = 'EUR'` et `defaultCurrencyLocale = 'en-EN'` et d’une fonction `normalizeCurrencyCode` pour garantir un code devise ISO valide avant d’appeler `Intl.NumberFormat`.
- Mise à jour de `getCurrency` pour utiliser le parseur et basculer vers des valeurs par défaut si les données sont manquantes ou invalides afin d’éviter que `Intl.NumberFormat` lève une exception.
- Mise à jour de `loadConfigurationDT` dans `src/js/configuration.js` pour utiliser `parseConfigurationResponse` et empêcher l’erreur `data.forEach is not a function` lorsqu’une réponse n’est pas directement un tableau.

### Testing
- `node --check src/js/modules/mainFunction.js` exécuté et a réussi.
- `node --check src/js/configuration.js` exécuté et a réussi.
- `npm run build` exécuté mais bloqué par une erreur externe non liée au JS : l’import Google Fonts dans `src/css/mycss.less` retourne `Forbidden`, empêchant la compilation CSS/webpack (reste à corriger séparément).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fbe34ae708332ad6edbaeb83d800f)