### PR TITLE
Draft: Fix CSRF headers on frontend requests

### DIFF
--- a/src/js/listener/handlers/product_handlers.js
+++ b/src/js/listener/handlers/product_handlers.js
@@ -1,6 +1,7 @@
 import { showError } from "@nextcloud/dialogs";
 import { baseUrl } from "../../modules/mainFunction.js";
 import { getProduitsById, listProduit, updateDB } from "../../modules/ajaxRequest.js";
+import { csrfHeaders } from "../../modules/csrf.js";
 
 export function addProductToDevis() {
     const devisId = document.getElementById('devisid').dataset.id;
@@ -8,9 +9,9 @@ export function addProductToDevis() {
 
     fetch(baseUrl + '/insertProduitDevis', {
         method: 'POST',
-        headers: {
+        headers: csrfHeaders({
             'Content-Type': 'application/json'
-        },
+        }),
         body: JSON.stringify(produitDevis)
     })
         .then(function(response) {

--- a/src/js/modules/ajaxRequest.js
+++ b/src/js/modules/ajaxRequest.js
@@ -1,6 +1,7 @@
 import { showMessage, showSuccess, showError } from "@nextcloud/dialogs";
 import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 import { baseUrl, cur, getGlobal, insertCell, insertRow, modifyCell } from "./mainFunction.js";
+import { csrfHeaders, setCsrfRequestHeader } from "./csrf.js";
 
 /**
  * Update data
@@ -19,10 +20,9 @@ export async function updateDB(table, column, data, id) {
     try {
         const response = await fetch(baseUrl + '/update', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'requesttoken': OC.requestToken
-            },
+            headers: csrfHeaders({
+                'Content-Type': 'application/json'
+            }),
             body: JSON.stringify(myData)
         });
 
@@ -54,10 +54,9 @@ export function updateDBConfiguration(table, column, data, id) {
 
     fetch(baseUrl + '/updateConfiguration', {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'requesttoken': OC.requestToken
-        },
+        headers: csrfHeaders({
+            'Content-Type': 'application/json'
+        }),
         body: JSON.stringify(myData)
     })
     .then(response => {
@@ -78,10 +77,9 @@ export function updateDBConfiguration(table, column, data, id) {
 export function createCompany() {
     fetch(baseUrl + '/createCompany', {
         method: 'PUT',
-        headers: {
-            'Content-Type': 'application/json',
-            'requesttoken': OC.requestToken
-        }
+        headers: csrfHeaders({
+            'Content-Type': 'application/json'
+        })
     })
     .then(response => {
         if (response.ok) {
@@ -103,10 +101,9 @@ export function deleteCompany() {
     if (window.confirm(t('gestion', 'Are you sure you want to delete? (All data will be lost)'))) {
         fetch(baseUrl + '/deleteCompany', {
             method: 'DELETE',
-            headers: {
-                'Content-Type': 'application/json',
-                'requesttoken': OC.requestToken
-            }
+            headers: csrfHeaders({
+                'Content-Type': 'application/json'
+            })
         })
         .then(response => {
             if (response.ok) {
@@ -135,10 +132,9 @@ export function updateCurrentCompany(companyID) {
     
     fetch(baseUrl + '/updateSession', {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'requesttoken': OC.requestToken
-        },
+        headers: csrfHeaders({
+            'Content-Type': 'application/json'
+        }),
         body: JSON.stringify(myData)
     })
     .then(response => {
@@ -171,10 +167,9 @@ export function duplicateDB(table, id, callback=null, modifier=null) {
     if (window.confirm(t('gestion', 'Are you sure you want to duplicate?'))) {
         fetch(baseUrl + '/duplicate', {
             method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json',
-                'requesttoken': OC.requestToken
-            },
+            headers: csrfHeaders({
+                'Content-Type': 'application/json'
+            }),
             body: JSON.stringify(myData)
         })
         .then(response => {
@@ -207,10 +202,9 @@ export function deleteDB(table, id, callback=null, modifier=null) {
     if (window.confirm(t('gestion', 'Are you sure you want to delete?'))) {
         fetch(baseUrl + '/delete', {
             method: 'DELETE',
-            headers: {
-                'Content-Type': 'application/json',
-                'requesttoken': OC.requestToken
-            },
+            headers: csrfHeaders({
+                'Content-Type': 'application/json'
+            }),
             body: JSON.stringify(myData)
         })
         .then(response => {
@@ -243,10 +237,9 @@ export function drop(id, callback=null, modifier=null, value='up') {
     
     fetch(baseUrl + '/drop', {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'requesttoken': OC.requestToken
-        },
+        headers: csrfHeaders({
+            'Content-Type': 'application/json'
+        }),
         body: JSON.stringify(myData)
     })
     .then(response => {
@@ -268,10 +261,9 @@ export function drop(id, callback=null, modifier=null, value='up') {
 export function getStats() {
     fetch(baseUrl + '/getStats', {
         method: 'PROPFIND',
-        headers: {
-            'Content-Type': 'application/json',
-            'requesttoken': OC.requestToken
-        },
+        headers: csrfHeaders({
+            'Content-Type': 'application/json'
+        }),
     })
     .then(response => {
         if (response.ok) {
@@ -300,6 +292,7 @@ export function configuration(f1) {
     const request = new XMLHttpRequest();
     request.open('PROPFIND', baseUrl + '/getConfiguration', false);
     request.setRequestHeader('Content-Type', 'application/json');
+    setCsrfRequestHeader(request);
     request.onload = function () {
         if (request.status >= 200 && request.status < 300) {
             f1(request.responseText);
@@ -319,9 +312,9 @@ export function configuration(f1) {
 export function isconfig() {
     fetch(baseUrl + '/isconfig', {
         method: 'GET',
-        headers: {
+        headers: csrfHeaders({
             'Content-Type': 'application/json'
-        }
+        })
     })
     .then(response => response.json())
     .then(response => {
@@ -342,10 +335,9 @@ export function isconfig() {
 export function getAnnualTurnoverPerMonthNoVat(cur) {
     fetch(baseUrl + '/getAnnualTurnoverPerMonthNoVat', {
         method: 'PROPFIND',
-        headers: {
-            'Content-Type': 'application/json',
-            'requesttoken': OC.requestToken
-        }
+        headers: csrfHeaders({
+            'Content-Type': 'application/json'
+        })
     })
     .then(response => {
         if (response.ok) {
@@ -424,10 +416,9 @@ export function updateEditableConfiguration(myCase) {
 export function listProduit(lp, id, produitid) {
     fetch(baseUrl + '/getProduits', {
         method: 'PROPFIND',
-        headers: {
-            'Content-Type': 'application/json',
-            'requesttoken': OC.requestToken
-        }
+        headers: csrfHeaders({
+            'Content-Type': 'application/json'
+        })
     })
     .then(response => {
         if (response.ok) {
@@ -474,9 +465,9 @@ export function getProduitsById() {
 
     fetch(baseUrl + '/getProduitsById', {
         method: 'POST',
-        headers: {
+        headers: csrfHeaders({
             'Content-Type': 'application/json'
-        },
+        }),
         body: JSON.stringify(myData)
     })
     .then(response => {
@@ -613,10 +604,9 @@ export function getProduitsById() {
 export function saveNextcloud(myData) {
     fetch(baseUrl + '/savePDF', {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'requesttoken': OC.requestToken
-        },
+        headers: csrfHeaders({
+            'Content-Type': 'application/json'
+        }),
         body: JSON.stringify(myData)
     })
     .then(response => {
@@ -637,10 +627,9 @@ export function saveNextcloud(myData) {
 export function generateFacturXmlRequest(factureId, name, folder) {
     fetch(baseUrl + '/generateFacturXml', {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'requesttoken': OC.requestToken
-        },
+        headers: csrfHeaders({
+            'Content-Type': 'application/json'
+        }),
         body: JSON.stringify({ factureId, name, folder })
     })
     .then(response => {
@@ -668,7 +657,7 @@ export function getMailServerFrom(input) {
     var oReq = new XMLHttpRequest();
     oReq.open('PROPFIND', baseUrl + '/getServerFromMail', true);
     oReq.setRequestHeader("Content-Type", "application/json");
-    oReq.setRequestHeader("requesttoken", oc_requesttoken);
+    setCsrfRequestHeader(oReq);
     oReq.onload = function(e){
         if (this.status == 200) {
             input.value = JSON.parse(this.response)['mail'];
@@ -686,7 +675,7 @@ export function backup(){
     var oReq = new XMLHttpRequest();
     oReq.open('GET', baseUrl + '/backup', true);
     oReq.setRequestHeader("Content-Type", "application/json");
-    oReq.setRequestHeader("requesttoken", oc_requesttoken);
+    setCsrfRequestHeader(oReq);
     oReq.onload = function(){
         if (this.status == 200) {
             showSuccess(t('gestion', 'Save in')+' '+JSON.parse(this.response)['name']+'\n'+t('gestion','(do not forget to show hidden folders)'));
@@ -704,10 +693,9 @@ export function addShareUser(email){
 
     fetch(baseUrl + '/addShareUser', {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'requesttoken': OC.requestToken
-        },
+        headers: csrfHeaders({
+            'Content-Type': 'application/json'
+        }),
         body: JSON.stringify(myData)
     })
     .then(response => {
@@ -730,10 +718,9 @@ export function delShareUser(uid){
 
     fetch(baseUrl + '/delShareUser', {
         method: 'DELETE',
-        headers: {
-            'Content-Type': 'application/json',
-            'requesttoken': OC.requestToken
-        },
+        headers: csrfHeaders({
+            'Content-Type': 'application/json'
+        }),
         body: JSON.stringify(myData)
     })
     .then(response => {

--- a/src/js/modules/csrf.js
+++ b/src/js/modules/csrf.js
@@ -1,0 +1,37 @@
+/**
+ * Return the Nextcloud CSRF token exposed to frontend scripts.
+ *
+ * Nextcloud versions have exposed the token as either OC.requestToken or
+ * oc_requesttoken. Supporting both keeps the app compatible with older and
+ * newer supported instances.
+ */
+export function getRequestToken() {
+    return globalThis.OC?.requestToken || globalThis.oc_requesttoken;
+}
+
+/**
+ * Build headers with the CSRF token required by Nextcloud controllers.
+ *
+ * @param {Object} headers Additional request headers.
+ */
+export function csrfHeaders(headers = {}) {
+    const requestToken = getRequestToken();
+
+    return {
+        ...headers,
+        requesttoken: requestToken,
+        'X-Request-Token': requestToken,
+    };
+}
+
+/**
+ * Add the Nextcloud CSRF token to an XMLHttpRequest.
+ *
+ * @param {XMLHttpRequest} request
+ */
+export function setCsrfRequestHeader(request) {
+    const requestToken = getRequestToken();
+
+    request.setRequestHeader('requesttoken', requestToken);
+    request.setRequestHeader('X-Request-Token', requestToken);
+}

--- a/src/js/modules/mainFunction.js
+++ b/src/js/modules/mainFunction.js
@@ -2,6 +2,7 @@ import { showSuccess } from "@nextcloud/dialogs";
 import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 import { configuration, getStats, isconfig, updateEditable } from "./ajaxRequest.js";
 import { generateUrl } from "@nextcloud/router";
+import { csrfHeaders } from "./csrf.js";
 export var baseUrl = generateUrl('/apps/gestion');
 export var cur = null;
 export const defaultCurrencyCode = 'EUR';
@@ -229,9 +230,9 @@ export function getGlobal() {
 const url = baseUrl + '/getConfiguration';
 const options = {
     method: 'PROPFIND',
-    headers: {
+    headers: csrfHeaders({
         'Content-Type': 'application/json'
-    }
+    })
 };
 
 

--- a/src/js/objects/client.js
+++ b/src/js/objects/client.js
@@ -1,5 +1,6 @@
 import { updateDB } from "../modules/ajaxRequest.js";
 import { baseUrl, checkSelectPurJs, LoadDT} from "../modules/mainFunction.js";
+import { csrfHeaders, setCsrfRequestHeader } from "../modules/csrf.js";
 import { showSuccess, showError } from "@nextcloud/dialogs";
 
 export class Client {
@@ -49,6 +50,7 @@ export class Client {
   static newClient(dt) {
     var oReq = new XMLHttpRequest();
     oReq.open('POST', baseUrl + '/client/insert', true);
+    setCsrfRequestHeader(oReq);
     oReq.onload = function(e){
       if (this.status == 200) {
         showSuccess()
@@ -68,6 +70,7 @@ export class Client {
     var oReq = new XMLHttpRequest();
     oReq.open('PROPFIND', baseUrl + '/getClients', true);
     oReq.setRequestHeader("Content-Type", "application/json");
+    setCsrfRequestHeader(oReq);
     oReq.onload = function(e){
       if (this.status == 200) {
         LoadDT(clientDT, JSON.parse(this.response), Client);
@@ -86,6 +89,7 @@ export class Client {
     var oReq = new XMLHttpRequest();
     oReq.open('PROPFIND', baseUrl + '/getClients', true);
     oReq.setRequestHeader("Content-Type", "application/json");
+    setCsrfRequestHeader(oReq);
     oReq.onload = function(e){
       if (this.status == 200) {
         callback(JSON.parse(this.response));
@@ -101,9 +105,9 @@ export class Client {
 
     fetch(baseUrl + '/clientbyiddevis', {
       method: 'POST',
-      headers: {
+      headers: csrfHeaders({
         'Content-Type': 'application/json'
-      },
+      }),
       body: JSON.stringify(myData)
     })
     .then(response => {

--- a/src/js/objects/devis.js
+++ b/src/js/objects/devis.js
@@ -1,6 +1,7 @@
 import { generateUrl } from "@nextcloud/router";
 import { updateDB } from "../modules/ajaxRequest.js";
 import { baseUrl, checkSelectPurJs, LoadDT, showDone } from "../modules/mainFunction.js";
+import { csrfHeaders, setCsrfRequestHeader } from "../modules/csrf.js";
 
 export class Devis {
 
@@ -48,7 +49,8 @@ export class Devis {
    */
   static newDevis(dt) {
     fetch(baseUrl + '/devis/insert', {
-      method: 'POST'
+      method: 'POST',
+      headers: csrfHeaders()
     })
     .then(response => {
       if (response.ok) {
@@ -69,6 +71,7 @@ export class Devis {
     var oReq = new XMLHttpRequest();
     oReq.open('PROPFIND', baseUrl + '/getDevis', true);
     oReq.setRequestHeader("Content-Type", "application/json");
+    setCsrfRequestHeader(oReq);
     oReq.onload = function(e){
       if (this.status == 200) {
         LoadDT(devisDT, JSON.parse(this.response), Devis);
@@ -82,9 +85,9 @@ export class Devis {
   static getDevis(callback){
     fetch(baseUrl + '/getDevis', {
       method: 'PROPFIND',
-      headers: {
+      headers: csrfHeaders({
       'Content-Type': 'application/json'
-      }
+      })
     })
     .then(response => {
       if (response.ok) {

--- a/src/js/objects/facture.js
+++ b/src/js/objects/facture.js
@@ -1,6 +1,7 @@
 import { showError } from "@nextcloud/dialogs";
 import { generateUrl } from "@nextcloud/router";
 import { baseUrl, LoadDT, showDone } from "../modules/mainFunction.js";
+import { setCsrfRequestHeader } from "../modules/csrf.js";
 
 export class Facture {
 
@@ -50,6 +51,7 @@ export class Facture {
     var oReq = new XMLHttpRequest();
     oReq.open('PROPFIND', baseUrl + '/getFactures', true);
     oReq.setRequestHeader("Content-Type", "application/json");
+    setCsrfRequestHeader(oReq);
     oReq.onload = function(e){
       if (this.status == 200) {
         LoadDT(factureDT, JSON.parse(this.response), Facture);
@@ -70,6 +72,7 @@ export class Facture {
    static newFacture(dt) {
     var oReq = new XMLHttpRequest();
     oReq.open('POST', baseUrl + '/facture/insert', true);
+    setCsrfRequestHeader(oReq);
     oReq.onload = function(e){
       if (this.status == 200) {
         showDone()

--- a/src/js/objects/produit.js
+++ b/src/js/objects/produit.js
@@ -1,5 +1,6 @@
 import { showError } from "@nextcloud/dialogs";
 import { baseUrl, cur, LoadDT, showDone } from "../modules/mainFunction.js";
+import { setCsrfRequestHeader } from "../modules/csrf.js";
 
 export class Produit {
 
@@ -39,6 +40,7 @@ export class Produit {
     var oReq = new XMLHttpRequest();
     oReq.open('PROPFIND', baseUrl + '/getProduits', true);
     oReq.setRequestHeader("Content-Type", "application/json");
+    setCsrfRequestHeader(oReq);
     oReq.onload = function(e){
       if (this.status == 200) {
         LoadDT(productDT, JSON.parse(this.response), Produit);
@@ -56,6 +58,7 @@ export class Produit {
    static newProduct(dt) {
     var oReq = new XMLHttpRequest();
     oReq.open('POST', baseUrl + '/produit/insert', true);
+    setCsrfRequestHeader(oReq);
     oReq.onload = function(e){
       if (this.status == 200) {
         showDone()

--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -1,13 +1,14 @@
 import { showMessage } from "@nextcloud/dialogs";
 import { baseUrl } from "./modules/mainFunction.js";
 import { generateFacturXmlRequest } from "./modules/ajaxRequest.js";
+import { csrfHeaders } from "./modules/csrf.js";
 
 export function sendMail(myData) {
   fetch(baseUrl + "/sendPDF", {
     method: "POST",
-    headers: {
+    headers: csrfHeaders({
       "Content-Type": "application/json"
-    },
+    }),
     body: JSON.stringify(myData)
   })
   .then(response => {
@@ -47,10 +48,9 @@ export function capture(afterCapturefunction) {
   
   fetch(baseUrl + '/generatePDF', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'requesttoken': OC.requestToken
-    },
+    headers: csrfHeaders({
+      'Content-Type': 'application/json'
+    }),
     body: JSON.stringify({
       html: htmlContent,
       name: name,
@@ -102,10 +102,9 @@ export function captureFacturX() {
 
   fetch(baseUrl + '/generateFacturX', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'requesttoken': OC.requestToken
-    },
+    headers: csrfHeaders({
+      'Content-Type': 'application/json'
+    }),
     body: JSON.stringify({
       html:      htmlContent,
       name:      name,
@@ -173,10 +172,9 @@ export function sendFacturXToIopole() {
 
   fetch(baseUrl + '/sendFacturXToIopole', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'requesttoken': OC.requestToken
-    },
+    headers: csrfHeaders({
+      'Content-Type': 'application/json'
+    }),
     body: JSON.stringify({
       html: htmlContent,
       name: name,


### PR DESCRIPTION
### Motivation
- Prevent Nextcloud `CSRF check failed` errors by ensuring all frontend requests include the Nextcloud CSRF token. 
- Provide a single, compatible helper so both older and newer Nextcloud token globals are supported (`OC.requestToken` and `oc_requesttoken`).

### Description
- Add a new helper module `src/js/modules/csrf.js` that exposes `getRequestToken()`, `csrfHeaders()` and `setCsrfRequestHeader()` to standardize CSRF usage. 
- Replace ad-hoc token usage with `csrfHeaders()` for `fetch` calls and `setCsrfRequestHeader()` for `XMLHttpRequest` in various modules including `src/js/modules/ajaxRequest.js`, `src/js/objects/client.js`, `src/js/objects/devis.js`, `src/js/objects/facture.js`, `src/js/objects/produit.js`, `src/js/pdf.js` and `src/js/listener/handlers/product_handlers.js`. 
- Ensure both `requesttoken` and `X-Request-Token` headers are sent and keep existing `Content-Type` behavior unchanged. 
- Changes were applied on branch `codex/issue-0` and a draft PR was prepared; do not merge automatically.

### Testing
- Parsed modified JS modules with `node + acorn` to check for syntax errors which succeeded. 
- Ran a Python audit that scans `fetch`/`XMLHttpRequest` usages to detect missing CSRF helpers which reported no missing CSRF usages after the patch. 
- Attempted `npm run build` which was run but failed in this environment due to an external Google Fonts import returning HTTP `403`, not related to CSRF changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fc1efb9b08332b5f39bbb6d08d45c)