### PR TITLE
Remove the legacy Vue 2 dependency stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,15 +23,14 @@
     "watch": "NODE_ENV=development webpack --watch --config webpack.js"
   },
   "engines": {
-    "node": "^24.0.0",
-    "npm": "^11.0.0"
+    "node": ">=24.11.0 <25",
+    "npm": ">=11 <12"
   },
   "devDependencies": {
     "@nextcloud/browserslist-config": "^3.1.2",
-    "@nextcloud/dialogs": "7.3.0",
+    "@nextcloud/dialogs": "^7.4.0",
     "@nextcloud/l10n": "^3.4.1",
     "@nextcloud/router": "^3.1.0",
-    "@nextcloud/vue": "^8.37.0",
     "bootstrap": "^5.3.2",
     "bootstrap-icons": "^1.11.0",
     "canvg": "^4.0.3",
@@ -54,7 +53,6 @@
     "sass": "^1.93.2",
     "sass-loader": "^16.0.5",
     "style-loader": "^4.0.0",
-    "vue-loader": "^17.4.2",
     "webpack": "^5.105.1",
     "webpack-cli": "^6.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestion",
-  "version": "1.0.0",
+  "version": "3.0.5",
   "description": "Application pour gérer votre micro entreprise, client, facture, devis",
   "author": "Benjamin AIMARD",
   "contributors": [
@@ -23,7 +23,7 @@
     "watch": "NODE_ENV=development webpack --watch --config webpack.js"
   },
   "engines": {
-    "node": ">=24.11.0 <25",
+    "node": ">=24 <25",
     "npm": ">=11 <12"
   },
   "devDependencies": {

--- a/webpack.js
+++ b/webpack.js
@@ -1,6 +1,4 @@
-const path = require('path');
 const webpack = require('webpack');
-const { VueLoaderPlugin } = require('vue-loader');
 
 module.exports =
 [
@@ -27,74 +25,66 @@ module.exports =
       minimize: false
     },
     plugins: [
-      new VueLoaderPlugin(),
       new webpack.DefinePlugin({
-        'process.platform': JSON.stringify('browser') // or 'win32' if you need to simulate Windows
+        'process.platform': JSON.stringify('browser')
       }),
-     ],
+    ],
     resolve: {
       fallback: {
-          "http": false,
-          "https": false,
-          "stream": false,
-          process: require.resolve('process/browser')
+        "http": false,
+        "https": false,
+        "stream": false,
+        process: require.resolve('process/browser')
       },
-      alias: {
-        "icons": path.resolve(__dirname, "node_modules/vue-material-design-icons")
-      },
-      extensions: ['.vue', '.js', '.json'] // Assurez-vous d'inclure les extensions existantes
+      extensions: ['.js', '.json']
     },
     module: {
-        rules: [
+      rules: [
+        {
+          test: /\.less$/,
+          use: [
             {
-              test: /\.vue$/,
-              loader: 'vue-loader'
+              loader: 'style-loader',
             },
             {
-              test: /\.less$/,
-              use: [
-                {
-                  loader: 'style-loader',
-                },
-                {
-                  loader: 'css-loader',
-                },
-                {
-                  loader: 'less-loader',
-                },
-              ],
+              loader: 'css-loader',
             },
             {
-                test: /\.(css|scss)$/i,
-                use: [
-                    {
-                      loader: 'style-loader',
-                    },
-                    {
-                      loader: 'css-loader',
-                    },
-                    {
-                      loader: 'postcss-loader',
-                      options: {
-                        postcssOptions: {
-                          plugins: () => [
-                            require('autoprefixer')
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      loader: 'sass-loader',
-                    },
-                ],
-              },
-              {
-                test: /\.(ttf|eot|svg|gif|png)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-                use: [{
-                    loader: 'file-loader'
-                }]
-              },
+              loader: 'less-loader',
+            },
           ],
-      },
+        },
+        {
+          test: /\.(css|scss)$/i,
+          use: [
+            {
+              loader: 'style-loader',
+            },
+            {
+              loader: 'css-loader',
+            },
+            {
+              loader: 'postcss-loader',
+              options: {
+                postcssOptions: {
+                  plugins: () => [
+                    require('autoprefixer')
+                  ]
+                }
+              }
+            },
+            {
+              loader: 'sass-loader',
+            },
+          ],
+        },
+        {
+          test: /\.(ttf|eot|svg|gif|png)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+          use: [{
+            loader: 'file-loader'
+          }]
+        },
+      ],
+    },
   },
 ];


### PR DESCRIPTION
## What changed

- removes the direct `@nextcloud/vue` 8 dependency, which was the source of the nested Vue 2 dependency tree
- removes `vue-loader` and `VueLoaderPlugin` because the application does not contain Vue single-file components
- removes the unused `.vue` resolver and icon alias tied to the legacy Vue stack
- updates `@nextcloud/dialogs` to the latest 7.x release, which uses the maintained Vue 3 stack internally
- aligns the declared runtime with Node 24 and npm 11

## Why

Gestion currently uses plain JavaScript entry points and does not import `@nextcloud/vue` directly. Keeping `@nextcloud/vue` 8 therefore installed an unnecessary Vue 2 tree, including `@nextcloud/initial-state` 2.2.0, while `@nextcloud/dialogs` installed a separate Vue 3 tree. This produced duplicate framework versions and the Node engine warning.

## Expected result

After regenerating the lockfile, the direct Vue 2 tree and `@nextcloud/initial-state` 2.2.0 should disappear. `@nextcloud/dialogs` remains available and uses its maintained Vue 3 dependencies internally.

## Validation required locally

The GitHub connector cannot run npm or regenerate `package-lock.json`. From the branch, run:

```bash
rm -rf node_modules
npm install
npm ls vue @nextcloud/vue @nextcloud/initial-state
make build-js
```

Then commit the regenerated `package-lock.json`. The expected tree should no longer contain `@nextcloud/vue@8` or `@nextcloud/initial-state@2.2.0`.