### PR TITLE
Default client country to 'FR' and fix annual turnover table rendering

### DIFF
--- a/lib/Db/Bdd.php
+++ b/lib/Db/Bdd.php
@@ -119,7 +119,7 @@ class Bdd {
                                             $this->l->t('Address'),
                                             $this->l->t('zip_code'),
                                             $this->l->t('city_name'),
-                                            $this->l->t('country_code')
+                                            'FR'
                                         )
                                     );
         return true;

--- a/src/js/modules/ajaxRequest.js
+++ b/src/js/modules/ajaxRequest.js
@@ -349,11 +349,17 @@ export function getAnnualTurnoverPerMonthNoVat(cur) {
     .then(data => {
         var res = JSON.parse(data);
         var curY = "";
-        var curRow;
+        var curRow = null;
         var total = 0;
+        var tableBody = document.querySelector("#Statistical tbody");
+
+        if (tableBody) {
+            tableBody.innerHTML = "";
+        }
+
         res.forEach(function(item) {
             if (curY !== item.y) {
-                if (curY !== "") {
+                if (curRow !== null) {
                     insertCell(curRow, -1, cur.format(total));
                     total = 0;
                 }
@@ -361,13 +367,15 @@ export function getAnnualTurnoverPerMonthNoVat(cur) {
                 curRow = insertRow("Statistical", -1, 0, item.y);
                 modifyCell(curRow, (item.m), cur.format(Math.round(item.total)));
                 total += Math.round(item.total);
-            } else {
+            } else if (curRow !== null) {
                 modifyCell(curRow, (item.m), cur.format(Math.round(item.total)));
                 total += Math.round(item.total);
             }
         });
-        // At the end
-        insertCell(curRow, -1, cur.format(total));
+
+        if (curRow !== null) {
+            insertCell(curRow, -1, cur.format(total));
+        }
     })
     .catch(error => {
         showError(error);


### PR DESCRIPTION
### Motivation

- Ensure newly inserted clients have a sensible default country value instead of a translation key. 
- Prevent runtime errors and clear stale rows when building the annual turnover per-month table in the UI.

### Description

- Replace the translated default for `country_code` with a hardcoded `'FR'` in `insertClient` inside `lib/Db/Bdd.php`.
- In `getAnnualTurnoverPerMonthNoVat` (`src/js/modules/ajaxRequest.js`) initialize `curRow` to `null`, clear the `#Statistical tbody` before populating, and add null checks around row inserts and final total insertion to avoid referencing an uninitialized row.
- Keep existing data aggregation logic but guard DOM updates to prevent errors when no data is returned.

### Testing

- Ran PHP syntax check with `php -l` on the modified PHP file and it reported no errors. 
- Ran the JavaScript linter via `npm run lint` and there were no new linting errors. 
- No new automated unit tests were added or modified for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fd516364883328791e58467d5e55b)