### PR TITLE
Support custom invoice payment date and send default from UI

### DIFF
--- a/lib/Controller/FactureController.php
+++ b/lib/Controller/FactureController.php
@@ -44,6 +44,7 @@ class FactureController extends Controller {
 	 */
 	#[UseSession]
 	public function insertFacture() {
-		return $this->dataService->insertFacture();
+		$datePaiement = $this->request->getParam('date_paiement');
+		return $this->dataService->insertFacture($datePaiement);
 	}
 }

--- a/lib/Db/Bdd.php
+++ b/lib/Db/Bdd.php
@@ -150,7 +150,7 @@ class Bdd {
     /**
      * Insert invoice
      */
-    public function insertFacture($idNextcloud){
+    public function insertFacture($idNextcloud, $datePaiement = null){
         $last=0;
         $last = $this->lastinsertid("facture", $idNextcloud) + 1;
 
@@ -160,16 +160,21 @@ class Bdd {
             array($idNextcloud)
         );
 
+        $date = new \DateTimeImmutable();
+        $paymentDate = $datePaiement ?: $date->modify('+1 month')->format('Y-m-d');
+
         $sql = "INSERT INTO `".$this->tableprefix."facture`
         (`date`,`id_configuration`,`num`,`date_paiement`,`type_paiement`,`id_devis`,`user_id`)
         VALUES
-        (date('now'), ?, ?, date('now', '+1 month'), ?, 0, ?);";
+        (?, ?, ?, ?, ?, 0, ?);";
 
         $this->execSQLNoData(
             $sql,
             array(
+                $date->format('Y-m-d'),
                 $idNextcloud,
                 $pref[0]['facture_prefixe']."-".$last,
+                $paymentDate,
                 $this->l->t('Means of payment'),
                 $last
             )

--- a/lib/Service/DataService.php
+++ b/lib/Service/DataService.php
@@ -69,8 +69,8 @@ class DataService {
 		return $this->myDb->insertDevis($this->currentCompany());
 	}
 
-	public function insertFacture() {
-		return $this->myDb->insertFacture($this->currentCompany());
+	public function insertFacture($datePaiement = null) {
+		return $this->myDb->insertFacture($this->currentCompany(), $datePaiement);
 	}
 
 	public function insertProduit() {

--- a/src/js/objects/facture.js
+++ b/src/js/objects/facture.js
@@ -70,8 +70,13 @@ export class Facture {
    * @param {*} dt 
    */
    static newFacture(dt) {
+    const paymentDate = new Date();
+    paymentDate.setMonth(paymentDate.getMonth() + 1);
+    const defaultPaymentDate = paymentDate.toLocaleDateString('en-CA');
+
     var oReq = new XMLHttpRequest();
     oReq.open('POST', baseUrl + '/facture/insert', true);
+    oReq.setRequestHeader("Content-Type", "application/json");
     setCsrfRequestHeader(oReq);
     oReq.onload = function(e){
       if (this.status == 200) {
@@ -81,7 +86,9 @@ export class Facture {
         showError(this.response);
       }
     };
-    oReq.send();
+    oReq.send(JSON.stringify({
+      date_paiement: defaultPaymentDate,
+    }));
   }
 
 }


### PR DESCRIPTION
### Motivation

- Allow creating invoices with a specific payment date instead of always using a hardcoded next-month value in SQL.
- Send a sensible default payment date from the client when creating a new invoice to improve UX and ensure the server receives the intended date.

### Description

- Update `FactureController::insertFacture` to read `date_paiement` from the request and forward it to the service via `DataService::insertFacture`.
- Change `DataService::insertFacture` signature to accept an optional `$datePaiement` and pass it to the DB layer.
- Modify `Bdd::insertFacture` to accept the optional `$datePaiement`, compute a default one-month-ahead date when none is provided using `DateTimeImmutable`, and use parameterized SQL values to insert `date` and `date_paiement` explicitly.
- Update client JS in `src/js/objects/facture.js` to POST JSON including a `date_paiement` defaulted to one month ahead in `YYYY-MM-DD` (`en-CA`) format and set the `Content-Type` header for the request.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fd7cb7d5083328e2e31f9b3b5710f)