### PR TITLE
Use a dedicated stylesheet for mPDF rendering

### DIFF
--- a/css/pdf.css
+++ b/css/pdf.css
@@ -1,0 +1,201 @@
+/*
+ * Styles dedicated to mPDF.
+ *
+ * Keep this file free of CSS custom properties, flexbox, CSS grid and
+ * browser-only selectors. mPDF receives literal values so PDF rendering does
+ * not depend on the active Nextcloud theme.
+ */
+
+body,
+#PDFcontent {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    color: #222222;
+    background-color: #ffffff;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 12px;
+}
+
+.titre-centre {
+    width: 100%;
+    text-align: center;
+}
+
+.inline {
+    display: inline;
+}
+
+.img-fluid {
+    max-width: 100%;
+    height: auto;
+}
+
+.comment {
+    width: 100%;
+    margin: 20px 0;
+    line-height: 1.5;
+}
+
+.text-center {
+    text-align: center;
+}
+
+#headertable {
+    width: 100%;
+    margin: 0;
+    font-size: 12px;
+    text-align: left;
+    border-collapse: collapse;
+}
+
+#headertable tbody,
+#headertable tr,
+#headertable td {
+    color: #222222;
+    background-color: #ffffff;
+}
+
+#headertable td {
+    width: 33.333%;
+    padding: 10px;
+    vertical-align: top;
+}
+
+.table-produit,
+.table-prix {
+    width: 100%;
+    margin: 0 auto;
+    font-size: 12px;
+    border-collapse: collapse;
+    border: 1px solid #d8dce0;
+}
+
+.table-produit th,
+.table-prix th {
+    padding: 9px 8px;
+    color: #ffffff;
+    font-weight: bold;
+    text-align: center;
+    vertical-align: middle;
+    background-color: #00679e;
+    border: 1px solid #d8dce0;
+}
+
+.table-produit th {
+    text-align: left;
+}
+
+.table-produit td,
+.table-prix td {
+    padding: 8px;
+    color: #222222;
+    background-color: #ffffff;
+    border: 1px solid #d8dce0;
+}
+
+.table-produit tbody tr:nth-child(even) td,
+.table-prix tbody tr:nth-child(even) td {
+    background-color: #f3f5f7;
+}
+
+.table-produit th:nth-child(4),
+.table-produit th:nth-child(5),
+.table-produit th:nth-child(6),
+.table-produit th:nth-child(7),
+.table-produit th:nth-child(8),
+.table-produit td:nth-child(4),
+.table-produit td:nth-child(5),
+.table-produit td:nth-child(6),
+.table-produit td:nth-child(7),
+.table-produit td:nth-child(8),
+.table-prix td {
+    text-align: right;
+}
+
+.div-prix {
+    margin-top: 20px;
+}
+
+.table-section-title {
+    margin-top: 20px;
+    padding: 9px 12px;
+    color: #ffffff;
+    font-weight: bold;
+    text-align: center;
+    background-color: #00679e;
+    border: 1px solid #005782;
+}
+
+.alert-info-custom {
+    width: 75%;
+    margin: 20px auto;
+    padding: 10px 15px;
+    color: #15566b;
+    text-align: center;
+    background-color: #e8f4f8;
+    border: 1px solid #b8dce8;
+}
+
+.table-mentions-signature,
+.table-mentions-signature-facture {
+    width: 100%;
+    margin: 20px auto;
+    border-collapse: collapse;
+    table-layout: fixed;
+}
+
+.table-mentions-signature-facture {
+    width: 75%;
+}
+
+.cell-mentions,
+.cell-signature {
+    width: 50%;
+    padding: 15px;
+    color: #333333;
+    vertical-align: top;
+    background-color: #f8f9fa;
+    border: 1px solid #d8dce0;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 12px;
+}
+
+.mentions-titre {
+    margin-bottom: 10px;
+    color: #15566b;
+    font-size: 14px;
+    font-weight: bold;
+}
+
+.mentions-ligne {
+    margin: 4px 0;
+}
+
+.signature-title {
+    margin: 10px 0;
+    color: #333333;
+    font-size: 16px;
+    text-align: center;
+}
+
+.signature-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.signature-table th,
+.signature-table td {
+    padding: 10px;
+    color: #222222;
+    text-align: left;
+    background-color: #ffffff;
+    border: 1px solid #d8dce0;
+}
+
+.signature-table .row-signature th,
+.signature-table .row-signature td {
+    height: 80px;
+    vertical-align: top;
+    background-color: #fefefe;
+}

--- a/lib/Service/PdfService.php
+++ b/lib/Service/PdfService.php
@@ -90,7 +90,7 @@ class PdfService {
 				'tempDir' => '/tmp',
 			]);
 
-			$css = file_get_contents(__DIR__ . '/../../css/style.css');
+			$css = file_get_contents(__DIR__ . '/../../css/pdf.css');
 
 			$mpdf->WriteHTML($css, \Mpdf\HTMLParserMode::HEADER_CSS);
 			$mpdf->WriteHTML($html, \Mpdf\HTMLParserMode::HTML_BODY);
@@ -247,7 +247,7 @@ class PdfService {
 			'tempDir' => '/tmp',
 		]);
 
-		$css = file_get_contents(__DIR__ . '/../../css/style.css');
+		$css = file_get_contents(__DIR__ . '/../../css/pdf.css');
 
 		$mpdf->WriteHTML($css, \Mpdf\HTMLParserMode::HEADER_CSS);
 		$mpdf->WriteHTML($html, \Mpdf\HTMLParserMode::HTML_BODY);


### PR DESCRIPTION
## Problème

La feuille `css/style.css` de l’interface Nextcloud utilise désormais des variables CSS telles que `var(--gestion-primary)`. Ces variables sont correctement interprétées par les navigateurs, mais pas par mPDF. Les couleurs de fond des tableaux et de plusieurs blocs disparaissaient donc dans les PDF générés.

## Correction

- ajoute une feuille dédiée `css/pdf.css` ;
- utilise uniquement des valeurs CSS statiques compatibles avec mPDF ;
- restaure notamment :
  - les en-têtes bleus des tableaux ;
  - le texte blanc dans les en-têtes ;
  - les bordures et lignes alternées ;
  - le bloc des mentions légales ;
  - les styles des tableaux de prix et de signature ;
- conserve `css/style.css` pour l’interface Nextcloud et ses thèmes ;
- fait utiliser `css/pdf.css` par les deux flux mPDF :
  - PDF classique ;
  - PDF Factur-X et envoi vers un provider.

## Validation

Générer après déploiement :

- un devis PDF ;
- une facture PDF ;
- une facture Factur-X PDF+XML.

Les tableaux doivent retrouver leurs fonds bleus, leur texte blanc, leurs bordures et leurs lignes alternées.

Le connecteur GitHub ne permet pas d’exécuter mPDF dans l’instance Nextcloud ; la validation visuelle reste donc à effectuer localement.