### PR TITLE
Fix per-company PDF folder persistence

### DIFF
--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -52,14 +52,12 @@ class ConfigurationController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @param string $table
 	 * @param string $column
 	 * @param string $data
-	 * @param string $id
 	 * @UseSession
 	 */
 	#[UseSession]
-	public function updateConfiguration($table, $column, $data, $id) {
-		return $this->dataService->updateConfiguration($table, $column, $data, $id);
+	public function updateConfiguration($column, $data) {
+		return $this->dataService->updateConfiguration($column, $data);
 	}
 }

--- a/lib/Db/Bdd.php
+++ b/lib/Db/Bdd.php
@@ -45,7 +45,7 @@ class Bdd {
         $sql = "SELECT * FROM ".$this->tableprefix."client WHERE id_configuration = ?";
         return $this->execSQL($sql, array($idNextcloud));
     }
-    
+
     public function getClient($id,$idNextcloud){
         $sql = "SELECT * FROM ".$this->tableprefix."client WHERE id = ? AND id_configuration = ?";
         return $this->execSQL($sql, array($id,$idNextcloud));
@@ -90,7 +90,7 @@ class Bdd {
         $sql = "INSERT INTO `".$this->tableprefix."conf_share` (`id_configuration`, `id_nextcloud`) VALUES (?,?)";
         $this->execSQLNoData($sql, array($idConfiguration, $idNextcloud));
         return true;
-    } 
+    }
 
     public function delShareUser($idConfiguration, $idNextcloud){
         $sql = "DELETE FROM `".$this->tableprefix."conf_share` WHERE `id_configuration` = ? AND `id_nextcloud` = ?";
@@ -103,10 +103,6 @@ class Bdd {
         return $trace[2]['function'];
     }
 
-    /**
-     * INSERT client
-     * @$idnextcloud
-     */
     public function insertClient($idNextcloud){
         $sql = "INSERT INTO `".$this->tableprefix."client` (`id_configuration`,`nom`,`prenom`,`legal_one`,`entreprise`,`telephone`,`mail`,`adresse`,`zip_code`,`city_name`,`country_code`) VALUES (?,?,?,?,?,?,?,?,?,?,?)";
         $this->execSQLNoData($sql,array($idNextcloud,
@@ -125,9 +121,6 @@ class Bdd {
         return true;
     }
 
-    /**
-     * Insert quote
-     */
     public function insertDevis($idNextcloud){
         $last=0;
         $last = $this->lastinsertid("devis", $idNextcloud) + 1;
@@ -141,20 +134,16 @@ class Bdd {
                                                             `comment`,
                                                             `user_id`,
                                                             `delay`
-                                                        ) 
+                                                        )
                                                 VALUES (NOW(),?,?,0,'0.1',?,?,?,?);";
         $this->execSQLNoData($sql, array($idNextcloud,$this->l->t('Quote number'),$this->l->t('New'),$this->l->t('Comment'),$last,$this->l->t('Offer valid for 1 month from: ')));
         return true;
     }
 
-    /**
-     * Insert invoice
-     */
     public function insertFacture($idNextcloud, $datePaiement = null){
         $last=0;
         $last = $this->lastinsertid("facture", $idNextcloud) + 1;
 
-        //PREFIX
         $pref = $this->execSQLNoJsonReturn(
             "SELECT * FROM ".$this->tableprefix."configuration WHERE id = ?",
             array($idNextcloud)
@@ -184,14 +173,13 @@ class Bdd {
     }
 
     public function insertProduit($idNextcloud){
-
         $vat = $this->execSQLNoJsonReturn(
             "SELECT tva_default FROM ".$this->tableprefix."configuration WHERE id = ?",
             array($idNextcloud)
         )[0]['tva_default'];
 
         $sql = "INSERT INTO `".$this->tableprefix."produit` (`id_configuration`,`reference`,`description`,`prix_unitaire`,`vat`) VALUES (?,?,?,0,?);";
-        
+
         $this->execSQLNoData($sql, array(
             $idNextcloud,
             $this->l->t('Reference'),
@@ -216,13 +204,9 @@ class Bdd {
         $sqlSearchMax = "SELECT MIN(id) as id FROM `".$this->tableprefix."produit` WHERE id_configuration = ?";
         return $this->execSQLNoJsonReturn($sqlSearchMax, array($idNextcloud));
     }
-    
-    /**
-     * UPDATE
-     */
+
     public function gestion_update($table, $column, $data, $id, $id_configuration) {
         if (in_array($table, $this->whiteTable, true) && in_array($column, $this->whiteColumn, true)) {
-
             $safeData = strip_tags($data, '<br>');
             $safeData = html_entity_decode($safeData, ENT_QUOTES, 'UTF-8');
             $safeData = rtrim($safeData);
@@ -236,34 +220,19 @@ class Bdd {
         return false;
     }
 
-
     /**
-     * UPDATE
+     * Update a field of the configuration identified by its company ID.
      */
-    public function gestion_update_configuration($table, $column, $data, $id, $idNextcloud){
-        if(in_array($table, $this->whiteTable, true) && in_array($column, $this->whiteColumn, true)){
-            $safeData = $this->normalizeColumnData($column, htmlentities(rtrim($data)));
-            $sql = "UPDATE ".$this->tableprefix.$table." SET $column = ? WHERE `id` = ? AND `id_nextcloud` = ?";
-            $this->execSQLNoData($sql, array($safeData, $id, $idNextcloud));
-            return true;
+    public function gestion_updateConfiguration($column, $data, $idConfiguration){
+        if(!in_array($column, $this->whiteColumn, true)){
+            return false;
         }
-        return false;
-    }
 
-    /**
-     * UPDATE CONFIGURATION TABLE
-     * TODO Autorisation à faire cette action par l'utilisateur
-     */
-    public function gestion_updateConfiguration($table, $column, $data, $id){
-        if(in_array($table, $this->whiteTable, true) && in_array($column, $this->whiteColumn, true)){
-            $safeData = $this->normalizeColumnData($column, htmlentities(rtrim($data)));
-            $sql = "UPDATE ".$this->tableprefix.$table." SET $column = ? WHERE `id` = ?";
-            $this->execSQLNoData($sql, array($safeData, $id));
-            return true;
-        }
-        return false;
+        $safeData = $this->normalizeColumnData($column, htmlentities(rtrim($data)));
+        $sql = "UPDATE ".$this->tableprefix."configuration SET $column = ? WHERE `id` = ?";
+        $this->execSQLNoData($sql, array($safeData, $idConfiguration));
+        return true;
     }
-
 
     private function normalizeColumnData($column, $data){
         if ($column === 'zip_code') {
@@ -277,14 +246,11 @@ class Bdd {
         return $data;
     }
 
-    /**
-     * DUPLICATE
-     */
     public function gestion_duplicate($table, $id, $CurrentCompany){
         if(in_array($table, $this->whiteTable, true)){
             $sql = "SELECT * FROM ".$this->tableprefix.$table." WHERE `id` = ? AND `id_configuration` = ?";
             $res = $this->execSQLNoJsonReturn($sql, array($id, $CurrentCompany));
-            
+
             $sql = "INSERT INTO ".$this->tableprefix.$table." (";
             $sql2 = " VALUES (";
             foreach($res[0] as $key => $value){
@@ -293,11 +259,11 @@ class Bdd {
                     $sql2 .= "?,";
                 }
             }
-            
+
             $sql = rtrim($sql, ",");
             $sql2 = rtrim($sql2, ",");
             $sql .= ")".$sql2.")";
-            
+
             unset($res[0]['id']);
             $res[0]['user_id'] = $this->lastinsertid($table, $CurrentCompany) + 1;
 
@@ -305,7 +271,7 @@ class Bdd {
                 $res[0]['num'] = $this->execSQLNoJsonReturn("SELECT * FROM ".$this->tableprefix."configuration WHERE id = ?", array($CurrentCompany))[0]['facture_prefixe']."-".$res[0]['user_id'];
             }
             $this->execSQLNoData($sql, array_values($res[0]));
-            
+
             if($table == "devis"){
                 $sql = "SELECT * FROM ".$this->tableprefix."produit_devis WHERE `devis_id` = ? AND `id_configuration` = ?";
                 $res_produit_devis = $this->execSQLNoJsonReturn($sql, array($id, $CurrentCompany));
@@ -318,15 +284,12 @@ class Bdd {
                     $this->execSQLNoData($sql, array($id_devis, $CurrentCompany, $value['produit_id'], $value['quantite'], $value['discount']));
                 }
             }
-            
+
             return true;
         }
         return false;
     }
 
-    /**
-     * DROP
-     */
     public function gestion_drop($id, $value, $CurrentCompany){
         $sql_produits_devis_current = "SELECT * FROM ".$this->tableprefix."produit_devis WHERE `id` = ? AND `id_configuration` = ?";
         $produits_devis_current = $this->execSQLNoJsonReturn($sql_produits_devis_current, array($id, $CurrentCompany));
@@ -351,9 +314,6 @@ class Bdd {
         }
     }
 
-    /**
-     * DELETE
-     */
     public function gestion_delete($table, $id, $CurrentCompany){
         if(in_array($table, $this->whiteTable, true)){
             $sql = "DELETE FROM ".$this->tableprefix.$table." WHERE `id` = ? AND `id_configuration` = ?";
@@ -362,11 +322,6 @@ class Bdd {
         }
         return false;
     }
-
-    /**
-     * Check
-     * TODO id_possesseur à remplacer pour id_nextcloud à changer partout
-     */
 
     public function checkConfig($idConfiguration, $idNextcloud){
         $sql = "SELECT count(*) as res FROM `".$this->tableprefix."configuration` WHERE `id_nextcloud` = ?";
@@ -377,31 +332,30 @@ class Bdd {
         return $res;
     }
 
-    /** * Create a new company */ 
-  public function createCompany($idNextcloud){ 
-    $sql = "INSERT INTO ".$this->tableprefix."configuration (entreprise, nom, prenom, legal_one, legal_two, mail, telephone, adresse, path, id_nextcloud,mentions_default,tva_default,devise,facture_prefixe, vat_number, city_name, zip_code) VALUES (?, ?, ?, ?, ?, ?, ?, ?, '', ?, ?, '0',?,?,?,?,?);"; 
-    $this->execSQLNoData($sql, array( $this->l->t('Your company name'), 
-                                     $this->l->t('Your company contact last name'), 
-                                     $this->l->t('Your company contact first name'), 
-                                     $this->l->t('Company legal information line one'), 
-                                     $this->l->t('Company legal information line two'), 
-                                     $this->l->t('Your company email'), 
-                                     $this->l->t('Your company phone'), 
-                                     $this->l->t('Your company address'), 
-                                     $idNextcloud, $this->l->t('All Legal mentions, disclaimer or everything you want to place in the footer.'), 
-                                     $this->l->t('EUR'), 
-                                     $this->l->t('INVOICE'),
-                                     $this->l->t('Your company vat number'),
-                                     $this->l->t('Your company city name'),
-                                     ''));
-    return true; }
+    public function createCompany($idNextcloud){
+        $sql = "INSERT INTO ".$this->tableprefix."configuration (entreprise, nom, prenom, legal_one, legal_two, mail, telephone, adresse, path, id_nextcloud,mentions_default,tva_default,devise,facture_prefixe, vat_number, city_name, zip_code) VALUES (?, ?, ?, ?, ?, ?, ?, ?, '', ?, ?, '0',?,?,?,?,?);";
+        $this->execSQLNoData($sql, array( $this->l->t('Your company name'),
+                                         $this->l->t('Your company contact last name'),
+                                         $this->l->t('Your company contact first name'),
+                                         $this->l->t('Company legal information line one'),
+                                         $this->l->t('Company legal information line two'),
+                                         $this->l->t('Your company email'),
+                                         $this->l->t('Your company phone'),
+                                         $this->l->t('Your company address'),
+                                         $idNextcloud, $this->l->t('All Legal mentions, disclaimer or everything you want to place in the footer.'),
+                                         $this->l->t('EUR'),
+                                         $this->l->t('INVOICE'),
+                                         $this->l->t('Your company vat number'),
+                                         $this->l->t('Your company city name'),
+                                         ''));
+        return true;
+    }
 
     public function deleteCompany($idCompany, $idNextcloud){
         $sql = "SELECT * FROM `".$this->tableprefix."configuration` WHERE `id` = ?";
         $res = $this->execSQLNoJsonReturn($sql, array($idCompany));
-        
-        if ($res[0]['id_nextcloud'] == $idNextcloud){
 
+        if ($res[0]['id_nextcloud'] == $idNextcloud){
             $sql = "DELETE FROM `".$this->tableprefix."configuration` WHERE `id` = ? AND `id_nextcloud` = ?";
             $this->execSQLNoData($sql, array($idCompany, $idNextcloud));
 
@@ -422,28 +376,26 @@ class Bdd {
 
             $sql = "DELETE FROM `".$this->tableprefix."conf_share` WHERE `id_configuration` = ?";
             $this->execSQLNoData($sql, array($idCompany));
-            
+
             return true;
         }else{
-
             return false;
         }
     }
 
     public function isConfig($idConfiguration,$idNextcloud){
-        $changelog = 10; //+1 if you want changelog appear for everybody one time !
+        $changelog = 10;
 
         $sql = "SELECT count(*) as res FROM `".$this->tableprefix."configuration` WHERE `id_nextcloud` = ?";
         $res = json_decode($this->execSQL($sql, array($idNextcloud)))[0]->res;
 
-        // Utilisateur jamais utilisé l'application
         if ( $res < 1 ){
             return false;
         }else{
             $sql = "SELECT id as id, changelog as res FROM `".$this->tableprefix."configuration` WHERE `id` = ?";
             $res = json_decode($this->execSQL($sql, array($idConfiguration)))[0]->res;
             if($res < $changelog){
-                $this->gestion_update_configuration("configuration","changelog",$changelog,$idConfiguration,$idNextcloud);
+                $this->gestion_updateConfiguration("changelog", $changelog, $idConfiguration);
                 return false;
             }else{
                 return true;
@@ -451,44 +403,29 @@ class Bdd {
         }
     }
 
-    /**
-     * Number client
-     */
     public function numberClient($idNextcloud){
         $sql = "SELECT count(*) as c from ".$this->tableprefix."client WHERE `id_configuration` = ?;";
         return $this->execSQL($sql, array($idNextcloud));
     }
 
-    /**
-     * Number devis
-     */
     public function numberDevis($idNextcloud){
         $sql = "SELECT count(*) as c from ".$this->tableprefix."devis WHERE `id_configuration` = ?;";
         return $this->execSQL($sql, array($idNextcloud));
     }
-    
-    /**
-     * Number facture
-     */
+
     public function numberFacture($idNextcloud){
         $sql = "SELECT count(*) as c from ".$this->tableprefix."facture WHERE `id_configuration` = ?;";
         return $this->execSQL($sql, array($idNextcloud));
     }
 
-    /**
-     * Number produit
-     */
     public function numberProduit($id_configuration){
         $sql = "SELECT count(*) as c from ".$this->tableprefix."produit WHERE `id_configuration` = ?;";
         return $this->execSQL($sql, array($id_configuration));
     }
 
-    /**
-     * Annual turnover per month without VAT
-     */
     public function getAnnualTurnoverPerMonthNoVat($id_configuration){
-        $sql = "SELECT  EXTRACT(YEAR FROM ".$this->tableprefix."facture.date_paiement) as y, 
-                        EXTRACT(MONTH FROM ".$this->tableprefix."facture.date_paiement) as m, 
+        $sql = "SELECT  EXTRACT(YEAR FROM ".$this->tableprefix."facture.date_paiement) as y,
+                        EXTRACT(MONTH FROM ".$this->tableprefix."facture.date_paiement) as m,
                         sum(".$this->tableprefix."produit.prix_unitaire * ".$this->tableprefix."produit_devis.quantite) as total
                 FROM `".$this->tableprefix."facture`, `".$this->tableprefix."produit_devis`, `".$this->tableprefix."produit`
                 WHERE ".$this->tableprefix."facture.id_devis = ".$this->tableprefix."produit_devis.devis_id
@@ -499,9 +436,6 @@ class Bdd {
         return $this->execSQL($sql, array($id_configuration));
     }
 
-    /**
-     * Get last insert id
-     */
     public function lastinsertid($table,$idNextcloud){
         $sql = "SELECT max(user_id) as last_insert_id FROM `" . $this->tableprefix . $table . "` WHERE " . $this->tableprefix . $table .".id_configuration = ?;";
         $res = $this->execSQLNoJsonReturn($sql,array($idNextcloud));
@@ -520,7 +454,7 @@ class Bdd {
         $res[] = array("===client===");
         $sql = "SELECT * FROM ".$this->tableprefix."client";
         $res = array_merge($res, $this->execSQLNoJsonReturn($sql, array()));
-        
+
         $res[] = array("===devis===");
         $sql = "SELECT * FROM ".$this->tableprefix."devis";
         $res = array_merge($res,$this->execSQLNoJsonReturn($sql, array()));
@@ -544,10 +478,6 @@ class Bdd {
         return $res;
     }
 
-    /**
-     * @sql
-     * @array() //prepare statement
-     */
     private function execSQL($sql, $conditions){
         $stmt = $this->pdo->prepare($sql);
         $stmt->execute($conditions);
@@ -569,5 +499,4 @@ class Bdd {
         $stmt->closeCursor();
         return $data;
     }
-
 }

--- a/lib/Service/DataService.php
+++ b/lib/Service/DataService.php
@@ -85,11 +85,7 @@ class DataService {
 		return $this->myDb->gestion_update($table, $column, $data, $id, $this->currentCompany());
 	}
 
-	public function updateConfiguration($table, $column, $data, $id = null) {
-		if ($table !== 'configuration') {
-			return false;
-		}
-
+	public function updateConfiguration($column, $data) {
 		return $this->myDb->gestion_updateConfiguration(
 			'configuration',
 			$column,

--- a/lib/Service/DataService.php
+++ b/lib/Service/DataService.php
@@ -87,7 +87,6 @@ class DataService {
 
 	public function updateConfiguration($column, $data) {
 		return $this->myDb->gestion_updateConfiguration(
-			'configuration',
 			$column,
 			$data,
 			$this->currentCompany()

--- a/lib/Service/DataService.php
+++ b/lib/Service/DataService.php
@@ -85,8 +85,17 @@ class DataService {
 		return $this->myDb->gestion_update($table, $column, $data, $id, $this->currentCompany());
 	}
 
-	public function updateConfiguration($table, $column, $data, $id) {
-		return $this->myDb->gestion_updateConfiguration($table, $column, $data, $id);
+	public function updateConfiguration($table, $column, $data, $id = null) {
+		if ($table !== 'configuration') {
+			return false;
+		}
+
+		return $this->myDb->gestion_updateConfiguration(
+			'configuration',
+			$column,
+			$data,
+			$this->currentCompany()
+		);
 	}
 
 	public function duplicate($table, $id): DataResponse {

--- a/src/js/listener/handlers/configuration_handlers.js
+++ b/src/js/listener/handlers/configuration_handlers.js
@@ -51,10 +51,8 @@ async function updateSelectedFolder(nodes) {
                 'Content-Type': 'application/json'
             }),
             body: JSON.stringify({
-                table: 'configuration',
                 column: 'path',
-                data: selectedFolder,
-                id: theFolder.getAttribute('data-id') || ''
+                data: selectedFolder
             })
         });
 

--- a/src/js/listener/handlers/configuration_handlers.js
+++ b/src/js/listener/handlers/configuration_handlers.js
@@ -1,6 +1,7 @@
-import { getFilePickerBuilder } from "@nextcloud/dialogs";
-import { configuration, updateCurrentCompany, updateDBConfiguration } from "../../modules/ajaxRequest.js";
-import { path } from "../../modules/mainFunction.js";
+import { getFilePickerBuilder, showError, showSuccess } from "@nextcloud/dialogs";
+import { updateCurrentCompany } from "../../modules/ajaxRequest.js";
+import { baseUrl } from "../../modules/mainFunction.js";
+import { csrfHeaders } from "../../modules/csrf.js";
 
 const chooseFolderLabel = t('gestion', 'Choose work folder');
 
@@ -35,14 +36,36 @@ export function updateCurrentCompanySelection(target) {
     updateCurrentCompany(target.value);
 }
 
-function updateSelectedFolder(nodes) {
-    const values = nodes.map(node => node.path);
+async function updateSelectedFolder(nodes) {
+    const selectedFolder = nodes[0]?.path;
     const theFolder = document.getElementById('theFolder');
-    const table = theFolder.getAttribute('data-table');
-    const column = theFolder.getAttribute('data-column');
-    const id = theFolder.getAttribute('data-id');
 
-    updateDBConfiguration(table, column, values[0], id);
-    configuration(path);
-    document.getElementById('theFolder').value = values[0];
+    if (!selectedFolder || !theFolder) {
+        return;
+    }
+
+    try {
+        const response = await fetch(baseUrl + '/updateConfiguration', {
+            method: 'POST',
+            headers: csrfHeaders({
+                'Content-Type': 'application/json'
+            }),
+            body: JSON.stringify({
+                table: 'configuration',
+                column: 'path',
+                data: selectedFolder,
+                id: theFolder.getAttribute('data-id') || ''
+            })
+        });
+
+        if (!response.ok) {
+            throw new Error('Configuration update failed');
+        }
+
+        theFolder.value = selectedFolder;
+        showSuccess(t('gestion', 'Modification saved'));
+    } catch (error) {
+        console.error('Unable to save the selected folder:', error);
+        showError(t('gestion', 'There is an error with the format, please check the documentation'));
+    }
 }

--- a/src/js/modules/mainFunction.js
+++ b/src/js/modules/mainFunction.js
@@ -71,7 +71,7 @@ function normalizeCurrencyCode(currencyCode) {
             "previous": t('gestion', 'Previous'),
         }
     }
-}
+ }
 
 /**
  * 
@@ -209,7 +209,6 @@ export function path(response) {
     }
 
     folder.value = currentConfiguration.path || "";
-    folder.setAttribute('data-id', currentConfiguration.id || "");
 }
 
 

--- a/src/js/modules/mainFunction.js
+++ b/src/js/modules/mainFunction.js
@@ -195,15 +195,22 @@ export function modifyCell(r, positionColumn = -1, data){
 }
 
 /**
- * 
- * @param {*} res 
+ * Load the PDF save folder for the current company.
+ *
+ * @param {*} response
  */
- export function path(res) {
-    var myres = JSON.parse(res)[0];
+export function path(response) {
+    const configurationRows = parseConfigurationResponse(response);
+    const currentConfiguration = configurationRows[0] || {};
     const folder = document.getElementById("theFolder");
-    folder.value = myres.path;
-    folder.setAttribute('data-id', myres.id);
-};
+
+    if (!folder) {
+        return;
+    }
+
+    folder.value = currentConfiguration.path || "";
+    folder.setAttribute('data-id', currentConfiguration.id || "");
+}
 
 
 /**

--- a/templates/content/changelog.php
+++ b/templates/content/changelog.php
@@ -54,14 +54,14 @@
 	<hr/>
 	<h2><?php p($l->t('Special thanks to:')); ?></h2>
 	<ul>
-		<li><?php p($l->t('Timo RAINO - for the big work on legal notice for France')); ?></li>
+		<li>Timo RAINO - <?php p($l->t('for the big work on legal notice for France')); ?></li>
 		<li><?php p($l->t('The MIAGE class at the University of Bordeaux - for the extraordinary work on the application this year')); ?></li>
-		<li><?php p($l->t('Aaron Stevens - for the coffee ;)')); ?></li>
-		<li><?php p($l->t('@CarlKDE - for the coffee ;)')); ?></li>
-		<li><?php p($l->t('little5bull - for the coffee ;)')); ?></li>
-		<li><?php p($l->t('Someone - for the coffee ;)')); ?></li>
-		<li><?php p($l->t('somerandomNCuser - for the coffee ;)')); ?></li>
-		<li><?php p($l->t('OursSansPlus - for the coffee ;)')); ?></li>
+		<li>Aaron Stevens - <?php p($l->t('for the coffee ;)')); ?></li>
+		<li>@CarlKDE - <?php p($l->t('for the coffee ;)')); ?></li>
+		<li>little5bull - <?php p($l->t('for the coffee ;)')); ?></li>
+		<li>Someone - <?php p($l->t('for the coffee ;)')); ?></li>
+		<li>somerandomNCuser - <?php p($l->t('for the coffee ;)')); ?></li>
+		<li>OursSansPlus - <?php p($l->t('for the coffee ;)')); ?></li>
 	</ul>
 </div>
 

--- a/templates/content/changelog.php
+++ b/templates/content/changelog.php
@@ -5,11 +5,7 @@
 
 	<p style="font-size:14px;margin-bottom:20px;">
 		<?php p($l->t(
-			"⚠️ Important Update:\n\n" .
-			"Logos are now associated with the company you are currently using, based on its identifier number.\n\n" .
-			"In the application, at the top left of the navigation menu, you’ll see the name of your company followed by its ID (e.g., id: %s).\n\n" .
-			"To apply a logo to your company, you must prefix the logo file name with this ID number.\n\n" .
-			"For example, if your company ID is %s, rename your logo file from %s to %s.",
+			"⚠️ Important Update:\n\nLogos are now associated with the company you are currently using, based on its identifier number.\n\nIn the application, at the top left of the navigation menu, you’ll see the name of your company followed by its ID (e.g., id: %s).\n\nTo apply a logo to your company, you must prefix the logo file name with this ID number.\n\nFor example, if your company ID is %s, rename your logo file from %s to %s.",
 			['1', '1', 'logo.png', '1logo.png']
 		)); ?>
 	</p>
@@ -58,14 +54,14 @@
 	<hr/>
 	<h2><?php p($l->t('Special thanks to:')); ?></h2>
 	<ul>
-		<li>Timo RAINO - <?php p($l->t('for the big work on legal notice for France')); ?></li>
-		<li><?php p($l->t('The MIAGE class at the University of Bordeaux')); ?> - <?php p($l->t('for the extraordinary work on the application this year')); ?></li>
-		<li>Aaron Stevens - <?php p($l->t('for the coffee ;)')); ?></li>
-		<li>@CarlKDE - <?php p($l->t('for the coffee ;)')); ?></li>
-		<li>little5bull - <?php p($l->t('for the coffee ;)')); ?></li>
-		<li>Someone - <?php p($l->t('for the coffee ;)')); ?></li>
-		<li>somerandomNCuser - <?php p($l->t('for the coffee ;)')); ?></li>
-		<li>OursSansPlus - <?php p($l->t('for the coffee ;)')); ?></li>
+		<li><?php p($l->t('Timo RAINO - for the big work on legal notice for France')); ?></li>
+		<li><?php p($l->t('The MIAGE class at the University of Bordeaux - for the extraordinary work on the application this year')); ?></li>
+		<li><?php p($l->t('Aaron Stevens - for the coffee ;)')); ?></li>
+		<li><?php p($l->t('@CarlKDE - for the coffee ;)')); ?></li>
+		<li><?php p($l->t('little5bull - for the coffee ;)')); ?></li>
+		<li><?php p($l->t('Someone - for the coffee ;)')); ?></li>
+		<li><?php p($l->t('somerandomNCuser - for the coffee ;)')); ?></li>
+		<li><?php p($l->t('OursSansPlus - for the coffee ;)')); ?></li>
 	</ul>
 </div>
 

--- a/templates/navigation/index.php
+++ b/templates/navigation/index.php
@@ -56,7 +56,7 @@
 	</li>
 	<li class="app-navigation-item"><center><b><?= p($l->t('Save folder'));?></b></center></li>
 	<li class="app-navigation-entry">
-		<input style="margin-left:10px;width:270px;" id="theFolder" data-table="configuration" data-column="path" data-id="" type="text" placeholder="<?= p($l->t('Please choose a folder'));?>">
+		<input style="margin-left:10px;width:270px;" id="theFolder" type="text" placeholder="<?= p($l->t('Please choose a folder'));?>">
 	</li>
 	
 	<li><center><a href="#"><button id="about" style="margin-left:10px;width:270px;"><?php p($l->t('About'));?></button></a></center></li>


### PR DESCRIPTION
## Problèmes corrigés

### Persistance du dossier PDF par société

Le dossier choisi avec le sélecteur Nextcloud n’était pas correctement rechargé ni toujours enregistré dans `gestion_configuration.path` :

- `getConfiguration` peut renvoyer une réponse doublement encodée en JSON ;
- `path()` ne la décodait qu’une fois, ce qui affichait `undefined` ;
- l’interface modifiait la valeur du champ sans attendre la réussite de l’enregistrement ;
- l’identifiant de société envoyé par le navigateur était utilisé directement côté serveur.

### Issue #551 — chaînes de traduction découpées

Les phrases de remerciement du changelog étaient séparées entre texte brut et appels `$l->t()`, ce qui empêchait une traduction correcte selon les recommandations Nextcloud.

## Corrections

- utilise `parseConfigurationResponse()` pour charger correctement le chemin ;
- affiche une chaîne vide si aucun dossier n’est configuré ;
- attend la réponse de `/updateConfiguration` avant de mettre à jour `#theFolder` ;
- affiche une erreur si l’enregistrement échoue ;
- ne déclenche plus de rechargement prématuré de la configuration après la sélection ;
- côté serveur, limite la mise à jour à la table `configuration` ;
- ignore l’identifiant de société fourni par le navigateur ;
- utilise systématiquement la société active de la session `CurrentCompany` pour mettre à jour `gestion_configuration.path` ;
- remplace les traductions fragmentées du bloc « Special thanks » par des phrases complètes dans chaque appel `$l->t()` ;
- regroupe également le long message « Important Update » en une seule chaîne traduisible.

Closes #551

## Résultat attendu

Chaque société conserve son propre dossier de sauvegarde. Après sélection de `/Documents`, la colonne `path` de la société active doit être mise à jour et le champ doit afficher ce chemin après rechargement.

Les chaînes du changelog peuvent désormais être extraites et traduites comme des phrases complètes.

## Validation locale

1. choisir un dossier pour une société ;
2. vérifier la colonne `path` dans `oc_gestion_configuration` ;
3. recharger la page ;
4. changer de société et choisir un autre dossier ;
5. vérifier que les deux chemins restent distincts ;
6. générer un devis PDF, une facture PDF et un fichier Factur-X ;
7. exécuter l’extraction ou la vérification i18n et vérifier l’absence de chaîne découpée dans `templates/content/changelog.php`.

Cette branche ne modifie pas les autres fonctions de `ajaxRequest.js`.