### PR TITLE
Fix appstore packaging rsync excludes and bump version to 3.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,9 @@ prepare-appstore:
 	rm -rf $(appstore_build_directory)
 	mkdir -p $(appstore_build_directory)
 	rsync -a \
-	--exclude-vcs \
+	--exclude="/.git" \
+	--exclude="/.gitignore" \
+	--exclude="/.gitattributes" \
 	--exclude="/build" \
 	--exclude="/tests" \
 	--exclude="/Makefile" \

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@ If you require adaptations to comply with your country's regulations, please ope
 [![Donate](https://img.shields.io/badge/Donate-Buy%20me%20a%20coffee-yellow.svg)](https://www.buymeacoffee.com/benjaminaimard)
 
 ]]></description>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
     <licence>agpl</licence>
     <author mail="benjamin@cybercorp.fr" homepage="https://github.com/baimard">Benjamin AIMARD</author>
     <namespace>Gestion</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gestion",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gestion",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@nextcloud/browserslist-config": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestion",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Application pour gérer votre micro entreprise, client, facture, devis",
   "author": "Benjamin AIMARD",
   "contributors": [


### PR DESCRIPTION
### Motivation
- The CI runner failed when packaging for the Nextcloud appstore because `rsync --exclude-vcs` is not supported in the environment used by the action. 
- Bump the app/npm version to avoid GitHub Actions cache issues when publishing the store package.

### Description
- Replace `--exclude-vcs` in `prepare-appstore` with explicit rsync excludes for `/.git`, `/.gitignore` and `/.gitattributes` in `Makefile` to avoid the unknown option error. 
- Bump application and npm versions from `3.2.0` to `3.2.1` in `appinfo/info.xml`, `package.json` and `package-lock.json` for a cache-safe release. 
- Changes are on the branch `codex/issue-0-appstore-package-fix` and are limited to packaging/version files to preserve PHP 8+ and Nextcloud compatibility.

### Testing
- Ran `git diff --check`, which succeeded with no whitespace errors. 
- Ran `make prepare-appstore`, which completed and produced the expected `build/artifacts/appstore/gestion` tree. 
- Ran `make appstore`, which stops at `sign-appstore` because signing keys are not provided in this environment, so packaging/signing cannot complete here (expected failure due to missing `sign_app_private_key`/`sign_app_certificate`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72422e86ac8332b399a67563ea092b)