### PR TITLE
Remove Twitter publish step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,13 +127,3 @@ jobs:
           appstore_token: ${{ secrets.APPSTORE_TOKEN }}
           download_url: ${{ steps.attach_to_release.outputs.browser_download_url }}
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Twitter
-        uses: Eomm/why-don-t-you-tweet@v1
-        with:
-          tweet-message: "Nextcloud Gestion is here! Check the new release ${{ github.event.release.tag_name }}. Don't forget to clear your cache ;) #Nextcloud #release #opensource"
-        env:
-          TWITTER_CONSUMER_API_KEY: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
-          TWITTER_CONSUMER_API_SECRET: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
-          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}


### PR DESCRIPTION
### Motivation
- Stop automatically posting a tweet at the end of the release workflow to remove the dependency on the Twitter action and credentials.

### Description
- Remove the `Twitter` step (the `Eomm/why-don-t-you-tweet@v1` usage and its inputs/env) from `.github/workflows/release.yml` so the release job now ends after uploading the app to the Nextcloud appstore.

### Testing
- Ran `git diff --check` which passed for the modified YAML.
- Attempted to create a draft PR with the GitHub CLI but the environment is not authenticated, so the PR was not opened here; please create a draft PR from a branch named `codex/issue-<number>` as required by repository rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72481091248332a2dae16d53f23db8)