### PR TITLE
Fix JavaScript build in production release packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Node.js 24
+        uses: actions/setup-node@1e60f620b9541d7c243d3c8f9a0fca98a5b2d63f # v4
+        with:
+          node-version: '24'
+
       - name: Install Composer dependencies (no-dev)
         run: |
           cd ${{ env.APP_NAME }}
           composer install --no-dev --prefer-dist --no-progress --no-suggest
+
+      - name: Install JavaScript dependencies
+        working-directory: ${{ env.APP_NAME }}
+        run: npm install
+
+      - name: Build production JavaScript
+        working-directory: ${{ env.APP_NAME }}
+        run: make build-js-production
+
+      - name: Verify production JavaScript bundles
+        working-directory: ${{ env.APP_NAME }}
+        run: make verify-js-production
 
       - name: Checkout server ${{ fromJSON(steps.appinfo.outputs.result).nextcloud.min-version }}
         continue-on-error: true

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,13 @@ build-js:
 build-js-production:
 	npm run build
 
+.PHONY: verify-js-production
+verify-js-production:
+	@test -d js || (echo "Missing generated js directory" && exit 1)
+	@test -s js/client.app.js || (echo "Missing js/client.app.js" && exit 1)
+	@test -s js/configuration.app.js || (echo "Missing js/configuration.app.js" && exit 1)
+	@test -s js/factureShow.app.js || (echo "Missing js/factureShow.app.js" && exit 1)
+
 watch-js:
 	npm run watch
 
@@ -120,7 +127,7 @@ source:
 # Builds the source package for the app store, ignores php and js tests.
 # The appstore package is signed before archiving, as required by Nextcloud.
 .PHONY: appstore
-appstore: prepare-appstore sign-appstore
+appstore: verify-js-production prepare-appstore sign-appstore
 	tar cvzf $(appstore_package_name).tar.gz -C $(appstore_build_directory) $(app_name)
 
 .PHONY: prepare-appstore
@@ -132,6 +139,7 @@ prepare-appstore:
 	--exclude="/.gitignore" \
 	--exclude="/.gitattributes" \
 	--exclude="/build" \
+	--exclude="/dist" \
 	--exclude="/tests" \
 	--exclude="/Makefile" \
 	--exclude="/*.log" \

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@ If you require adaptations to comply with your country's regulations, please ope
 [![Donate](https://img.shields.io/badge/Donate-Buy%20me%20a%20coffee-yellow.svg)](https://www.buymeacoffee.com/benjaminaimard)
 
 ]]></description>
-    <version>3.2.2</version>
+    <version>3.2.3</version>
     <licence>agpl</licence>
     <author mail="benjamin@cybercorp.fr" homepage="https://github.com/baimard">Benjamin AIMARD</author>
     <namespace>Gestion</namespace>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestion",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Application pour gérer votre micro entreprise, client, facture, devis",
   "author": "Benjamin AIMARD",
   "contributors": [

--- a/templates/content/changelog.php
+++ b/templates/content/changelog.php
@@ -1,7 +1,7 @@
 <div syle="display: none;" id="modalConfig" class="modal">
 <div class="modal-content">
 	<span class="modalClose">&times;</span>
-	<h2><?php p($l->t('Welcome to GESTION')); ?> 3.2.0</h2>
+	<h2><?php p($l->t('Welcome to GESTION')); ?> 3.2.3</h2>
 
 	<p style="font-size:14px;margin-bottom:20px;">
 		<?php p($l->t(
@@ -47,7 +47,7 @@
 
 	<hr/>
 	<h2><?php p($l->t('Changelog')); ?></h2>
-	<h3>Version 3.2.0</h3>
+	<h3>Version 3.2.3</h3>
 	<p style="font-size:14px;"><?php p($l->t('This version focuses on electronic invoicing and prepares Gestion for the French e-invoicing transition.')); ?></p>
 	<p><a href="https://github.com/baimard/gestion/releases"><?php p($l->t('Releases')); ?></a></p>
 


### PR DESCRIPTION
## Problème

Le workflow de publication construisait directement le paquet App Store avec `make appstore`, sans installer les dépendances JavaScript ni lancer Webpack.

Comme le répertoire `js/` est ignoré par Git, les bundles n’existaient pas dans le checkout GitHub Actions. Le paquet publié ne contenait donc aucun JavaScript et l’application déployée en production était incomplète.

## Corrections

- configure Node.js 24 dans le workflow de release ;
- installe les dépendances avec `npm install` ;
- exécute `make build-js-production` avant le packaging ;
- ajoute la cible `verify-js-production` pour vérifier la présence de bundles essentiels ;
- fait dépendre `appstore` de cette vérification, afin qu’un paquet incomplet ne puisse plus être signé ;
- exclut `dist/` du paquet de production.

## Bundles vérifiés

- `js/client.app.js`
- `js/configuration.app.js`
- `js/factureShow.app.js`

## Résultat attendu

Le paquet publié doit contenir le répertoire `js/` et tous les bundles Webpack nécessaires, tout en excluant les fichiers de développement tels que `src/`, `node_modules/`, `dist/`, `package.json` et `webpack.js`.

## Validation

Lors de la prochaine release, les logs GitHub Actions doivent montrer successivement :

1. installation de Node.js ;
2. installation npm ;
3. compilation Webpack en production ;
4. vérification des bundles ;
5. création et signature du paquet App Store.

La vérification empêche désormais explicitement la publication si le répertoire `js/` ou l’un des bundles essentiels est absent.