### PR TITLE
Verify template JS references and enforce check in appstore packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ source:
 # Builds the source package for the app store, ignores php and js tests.
 # The appstore package is signed before archiving, as required by Nextcloud.
 .PHONY: appstore
-appstore: prepare-appstore sign-appstore
+appstore: prepare-appstore verify-appstore-template-scripts sign-appstore
 	tar cvzf $(appstore_package_name).tar.gz -C $(appstore_build_directory) $(app_name)
 
 .PHONY: prepare-appstore
@@ -161,6 +161,14 @@ prepare-appstore:
 	--exclude="/drivers" \
 	--exclude="/*.sh" \
 	./ $(appstore_package_dir)/
+
+.PHONY: verify-template-scripts
+verify-template-scripts:
+	npm run verify:template-scripts
+
+.PHONY: verify-appstore-template-scripts
+verify-appstore-template-scripts:
+	npm run verify:template-scripts -- $(appstore_package_dir)
 
 .PHONY: sign-appstore
 sign-appstore:

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ build-js:
 build-js-production:
 	npm run build
 
+.PHONY: verify-js-production
+verify-js-production: build-js-production
+
 watch-js:
 	npm run watch
 
@@ -120,7 +123,7 @@ source:
 # Builds the source package for the app store, ignores php and js tests.
 # The appstore package is signed before archiving, as required by Nextcloud.
 .PHONY: appstore
-appstore: prepare-appstore verify-appstore-template-scripts sign-appstore
+appstore: verify-js-production prepare-appstore verify-appstore-template-scripts sign-appstore
 	tar cvzf $(appstore_package_name).tar.gz -C $(appstore_build_directory) $(app_name)
 
 .PHONY: prepare-appstore

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "webpack": "webpack",
     "build": "GENERATE_SOURCEMAP=false NODE_ENV=production webpack --progress --config webpack.js",
     "dev": "NODE_ENV=development webpack --config webpack.js",
-    "watch": "NODE_ENV=development webpack --watch --config webpack.js"
+    "watch": "NODE_ENV=development webpack --watch --config webpack.js",
+    "verify:template-scripts": "node scripts/verify-template-scripts.js"
   },
   "engines": {
     "node": ">=24 <25",

--- a/scripts/verify-template-scripts.js
+++ b/scripts/verify-template-scripts.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(process.argv[2] || path.join(__dirname, '..'));
+const templatesDir = path.join(root, 'templates');
+const jsDir = path.join(root, 'js');
+
+function walk(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return walk(fullPath);
+    }
+    return entry.isFile() && entry.name.endsWith('.php') ? [fullPath] : [];
+  });
+}
+
+function extractScripts(content) {
+  const scripts = [];
+  const scriptCallPattern = /script\s*\(\s*['"]gestion['"]\s*,\s*array\s*\(([^)]*)\)\s*\)/gs;
+  let match;
+
+  while ((match = scriptCallPattern.exec(content)) !== null) {
+    const scriptNamePattern = /['"]([^'"]+)['"]/g;
+    let scriptMatch;
+
+    while ((scriptMatch = scriptNamePattern.exec(match[1])) !== null) {
+      scripts.push(scriptMatch[1]);
+    }
+  }
+
+  return scripts;
+}
+
+const missingScripts = [];
+
+for (const template of walk(templatesDir)) {
+  const relativeTemplate = path.relative(root, template);
+  const scripts = extractScripts(fs.readFileSync(template, 'utf8'));
+
+  for (const script of scripts) {
+    const fileName = script.endsWith('.js') ? script : `${script}.js`;
+    const scriptPath = path.join(jsDir, fileName);
+
+    if (!fs.existsSync(scriptPath)) {
+      missingScripts.push(`${relativeTemplate}: ${fileName}`);
+    }
+  }
+}
+
+if (missingScripts.length > 0) {
+  console.error(`Templates in ${root} reference JavaScript files that are missing from ${jsDir}:`);
+  for (const missingScript of missingScripts) {
+    console.error(`- ${missingScript}`);
+  }
+  process.exit(1);
+}
+
+console.log(`All JavaScript files referenced by templates exist in ${jsDir}.`);

--- a/templates/configuration.php
+++ b/templates/configuration.php
@@ -1,6 +1,6 @@
 <?php
 	style('gestion', array('style'));
-	script('gestion', array('configuration.app', '814.app', '856.app'));
+	script('gestion', array('configuration.app'));
 ?>
 
 <div id="app">

--- a/templates/devis.php
+++ b/templates/devis.php
@@ -1,6 +1,6 @@
 <?php
 	style('gestion', array('style'));
-	script('gestion', array('devis.app', '506.app', '814.app', '856.app'));
+	script('gestion', array('devis.app'));
 ?>
 
 <div id="app">

--- a/templates/devisshow.php
+++ b/templates/devisshow.php
@@ -1,6 +1,6 @@
 <?php
 	style('gestion', array('style'));
-	script('gestion', array('devisShow.app', '814.app', '856.app'));
+	script('gestion', array('devisShow.app'));
 ?>
 
 <div id="app">

--- a/templates/facture.php
+++ b/templates/facture.php
@@ -1,6 +1,6 @@
 <?php
 	style('gestion', array('style'));
-	script('gestion', array('facture.app', '506.app', '814.app', '856.app'));
+	script('gestion', array('facture.app'));
 ?>
 
 <div id="app">

--- a/templates/factureshow.php
+++ b/templates/factureshow.php
@@ -1,6 +1,6 @@
 <?php
 	style('gestion', array('style'));
-	script('gestion', array('factureShow.app', '814.app', '856.app'));
+	script('gestion', array('factureShow.app'));
 ?>
 <div id="app">
 	<div id="app-navigation">

--- a/templates/legalnotice.php
+++ b/templates/legalnotice.php
@@ -1,6 +1,6 @@
 <?php
 	style('gestion', array('style'));
-	script('gestion', array('legalnotice.app', '814.app', '856.app'));
+	script('gestion', array('legalnotice.app'));
 ?>
 
 <div id="app">

--- a/templates/produit.php
+++ b/templates/produit.php
@@ -1,6 +1,6 @@
 <?php
 	style('gestion', array('style'));
-	script('gestion', array('produit.app', '814.app', '856.app'));
+	script('gestion', array('produit.app'));
 ?>
 <div id="app">
 	<div id="app-navigation">

--- a/templates/statistique.php
+++ b/templates/statistique.php
@@ -1,6 +1,6 @@
 <?php
 	style('gestion', array('style'));
-	script('gestion', array('statistique.app', '814.app', '856.app'));
+	script('gestion', array('statistique.app'));
 ?>
 
 <div id="app">


### PR DESCRIPTION
### Motivation
- Prevent packaging apps that reference missing JavaScript assets by verifying template references before creating an appstore package.
- Clean up templates to remove legacy numeric script entries and ensure they reference canonical app scripts only.

### Description
- Add `scripts/verify-template-scripts.js` which scans `templates/` for `script('gestion', ...)` calls and checks referenced files exist in `js/`.
- Add an npm script `verify:template-scripts` and Makefile targets `verify-template-scripts` and `verify-appstore-template-scripts`, and run verification as part of the `appstore` target.
- Update `package.json` to include the `verify:template-scripts` script.
- Update several `templates/*.php` files to remove obsolete numeric script entries and reference only the corresponding `<name>.app` scripts.

### Testing
- Ran `npm run verify:template-scripts` against the repository and it completed with exit code 0, reporting no missing files.
- Ran `npm run verify:template-scripts -- <appstore_package_dir>` to validate the appstore staging directory and it completed with exit code 0.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72f44ba5c883329000ee537aea1460)