### PR TITLE
Bump version to 3.2.4 and fix GitHub Actions setup-node reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js 24
-        uses: actions/setup-node@1e60f620b9541d7c243d3c8f9a0fca98a5b2d63f # v4
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@ If you require adaptations to comply with your country's regulations, please ope
 [![Donate](https://img.shields.io/badge/Donate-Buy%20me%20a%20coffee-yellow.svg)](https://www.buymeacoffee.com/benjaminaimard)
 
 ]]></description>
-    <version>3.2.3</version>
+    <version>3.2.4</version>
     <licence>agpl</licence>
     <author mail="benjamin@cybercorp.fr" homepage="https://github.com/baimard">Benjamin AIMARD</author>
     <namespace>Gestion</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gestion",
-  "version": "3.2.2",
+  "version": "3.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gestion",
-      "version": "3.2.2",
+      "version": "3.2.4",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@nextcloud/browserslist-config": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestion",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Application pour gérer votre micro entreprise, client, facture, devis",
   "author": "Benjamin AIMARD",
   "contributors": [


### PR DESCRIPTION
### Motivation
- Mettre à jour la version de l'application/npm à `3.2.4` pour préparer une nouvelle release. 
- Résoudre l’erreur GitHub Actions liée à une référence de commit introuvable pour `actions/setup-node` en utilisant une référence de version stable.

### Description
- Mise à jour de la version dans `appinfo/info.xml` de `3.2.3` à `3.2.4`.
- Mise à jour de la version dans `package.json` de `3.2.3` à `3.2.4` et alignement de la racine dans `package-lock.json` sur `3.2.4`.
- Correction de `.github/workflows/release.yml` en remplaçant `actions/setup-node@<sha>` introuvable par `actions/setup-node@v4` pour éviter l’erreur "Unable to resolve action".

### Testing
- Vérification XML via `php -r 'new SimpleXMLElement(file_get_contents("appinfo/info.xml"));'` a réussi.
- Construction JavaScript via `npm run build` a réussi et a généré les bundles attendus (avec avertissements de taille), et `npm run verify:template-scripts` a d’abord échoué avant la construction puis a réussi après `npm run build`.
- Vérification git/diff via `git diff --check` et `git diff --stat` n’a retourné aucune erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72f79c554883328fc2434908ac13c3)