### PR TITLE
Fix Makefile missing-separator and bump version to 3.2.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build-js-production:
 
 .PHONY: verify-js-production
 verify-js-production:
-  build-js-production
+	$(MAKE) build-js-production
 	@test -d js || (echo "Missing generated js directory" && exit 1)
 	@test -s js/client.app.js || (echo "Missing js/client.app.js" && exit 1)
 	@test -s js/configuration.app.js || (echo "Missing js/configuration.app.js" && exit 1)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@ If you require adaptations to comply with your country's regulations, please ope
 [![Donate](https://img.shields.io/badge/Donate-Buy%20me%20a%20coffee-yellow.svg)](https://www.buymeacoffee.com/benjaminaimard)
 
 ]]></description>
-    <version>3.2.4</version>
+    <version>3.2.5</version>
     <licence>agpl</licence>
     <author mail="benjamin@cybercorp.fr" homepage="https://github.com/baimard">Benjamin AIMARD</author>
     <namespace>Gestion</namespace>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestion",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "Application pour gérer votre micro entreprise, client, facture, devis",
   "author": "Benjamin AIMARD",
   "contributors": [


### PR DESCRIPTION
### Motivation
- Fix a failing `make build-js-production` caused by an invalid Makefile indentation and prepare a small release by bumping the app version to `3.2.5`.
- Keep application metadata consistent between Nextcloud and npm while preserving PHP 8+ and Nextcloud compatibility and following repository rules for branch/PR workflow.

### Description
- Replace the invalid indented line in `Makefile` with a proper recipe that calls `$(MAKE) build-js-production` to resolve the `missing separator` error.
- Bump the version from `3.2.4` to `3.2.5` in `package.json` and `appinfo/info.xml` to align npm and Nextcloud metadata.
- No dependency or compatibility constraints were altered by this change.

### Testing
- Ran `make build-js-production`, which executed the webpack production build and completed successfully (webpack compiled with warnings about large asset sizes). 
- Verified the version string updates by searching the repository for `3.2.5` and confirming the updated files; those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72f9941208833283857ead2d01f534)