### PR TITLE
Exclude AGENTS.md, scripts/ and translationfiles from release packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,10 @@ source:
 	--exclude-vcs \
 	--exclude="../$(app_name)/composer.json" \
 	--exclude="../$(app_name)/package*" \
+	--exclude="../$(app_name)/AGENTS.md" \
+	--exclude="../$(app_name)/scripts" \
 	--exclude="../$(app_name)/tests" \
+	--exclude="../$(app_name)/translationfiles" \
 	--exclude="../$(app_name)/src" \
 	--exclude="../$(app_name)/build" \
 	--exclude="../$(app_name)/js/node_modules" \
@@ -141,7 +144,10 @@ prepare-appstore:
 	--exclude="/.gitattributes" \
 	--exclude="/build" \
 	--exclude="/dist" \
+	--exclude="/AGENTS.md" \
+	--exclude="/scripts" \
 	--exclude="/tests" \
+	--exclude="/translationfiles" \
 	--exclude="/Makefile" \
 	--exclude="/*.log" \
 	--exclude="/phpunit*xml" \


### PR DESCRIPTION
### Motivation
- Avoid including development and maintenance files in release archives by excluding `AGENTS.md`, the `scripts/` directory and the legacy `translationfiles/` folder which is redundant with `l10n/`.

### Description
- Update `Makefile` `source` target to add `--exclude="../$(app_name)/AGENTS.md"`, `--exclude="../$(app_name)/scripts"` and `--exclude="../$(app_name)/translationfiles"`.
- Update `Makefile` `prepare-appstore` rsync excludes to add `--exclude="/AGENTS.md"`, `--exclude="/scripts"` and `--exclude="/translationfiles"`.
- Created branch `codex/issue-0` and committed the change with message `Exclude development files from release packages`.

### Testing
- Ran `make source` and confirmed the source archive does not contain the excluded paths with `tar tzf build/artifacts/source/gestion.tar.gz | rg '(^|/)gestion/(AGENTS\.md|scripts/|translationfiles/)'` which returned no matches.
- Ran `make prepare-appstore` and confirmed the prepared appstore tree does not contain the excluded paths with `find build/artifacts/appstore/gestion -maxdepth 2 -name AGENTS.md -o -path '*/scripts' -o -path '*/translationfiles'` which returned no results.
- All automated checks above succeeded, however a draft PR was not opened because `gh` is not authenticated and no remote is configured in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72fc1f9a8483329894be98a9d7cdce)