### PR TITLE
Add Factur‑X EN16931 generation, SIRET/SIREN extraction, refactor PDF/FacturX flow and UI tweaks

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@ If you require adaptations to comply with your country's regulations, please ope
 [![Donate](https://img.shields.io/badge/Donate-Buy%20me%20a%20coffee-yellow.svg)](https://www.buymeacoffee.com/benjaminaimard)
 
 ]]></description>
-    <version>3.2.5</version>
+    <version>3.2.6</version>
     <licence>agpl</licence>
     <author mail="benjamin@cybercorp.fr" homepage="https://github.com/baimard">Benjamin AIMARD</author>
     <namespace>Gestion</namespace>

--- a/css/style.css
+++ b/css/style.css
@@ -216,6 +216,22 @@
     vertical-align: middle;
 }
 
+button.electronic-invoice-help {
+    margin-top: 12px;
+    border: 1px solid #9a6700;
+    background-color: #ffc107;
+    color: #302000;
+    font-weight: 700;
+    box-shadow: 0 2px 5px rgba(154, 103, 0, 0.35);
+}
+
+button.electronic-invoice-help:hover,
+button.electronic-invoice-help:focus-visible {
+    border-color: #6f4a00;
+    background-color: #ffd54f;
+    color: #201500;
+}
+
 .ConfigurationHelp {
     margin-bottom: 20px;
 }

--- a/lib/Service/ElectronicInvoiceIdentifiers.php
+++ b/lib/Service/ElectronicInvoiceIdentifiers.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace OCA\Gestion\Service;
+
+final class ElectronicInvoiceIdentifiers {
+	public static function extractDigits(string $value, string $identifier): string {
+		if (!preg_match('/^\s*' . preg_quote($identifier, '/') . '\s*:\s*(.*)$/iu', $value, $matches)) {
+			return '';
+		}
+
+		return preg_replace('/\D+/', '', $matches[1]);
+	}
+}

--- a/lib/Service/FacturXService.php
+++ b/lib/Service/FacturXService.php
@@ -3,9 +3,12 @@
 namespace OCA\Gestion\Service;
 
 use DateTime;
+use OCA\Gestion\Controller\GestionFacturXWriter;
 
 class FacturXService
 {
+	public const PROFILE_ID = 'urn:cen.eu:en16931:2017';
+
     /**
      * Generate complete Factur-X PDF
      */
@@ -30,9 +33,10 @@ class FacturXService
     public function buildXml(
         object $invoice,
         object $company,
-        object $customer,
-        array $products
+        array $products,
+		?object $customer = null
     ): string {
+		$customer ??= $invoice;
 
         $totals = $this->calculateTotals($products);
 
@@ -46,6 +50,14 @@ class FacturXService
           trim($company->vat_number ?? ''),
           ENT_XML1
         );
+		$sellerSiret = ElectronicInvoiceIdentifiers::extractDigits(
+			(string)($company->legal_one ?? ''),
+			'SIRET'
+		);
+		$sellerSiren = ElectronicInvoiceIdentifiers::extractDigits(
+			(string)($company->legal_two ?? ''),
+			'SIREN'
+		);
 
         return $this->buildDocument(
             invoice: $invoice,
@@ -56,7 +68,9 @@ class FacturXService
             lineItemsXml: $lineItemsXml,
             taxXml: $taxXml,
             totals: $totals,
-            sellerVatId: $sellerVatId
+            sellerVatId: $sellerVatId,
+			sellerSiret: $sellerSiret,
+			sellerSiren: $sellerSiren
         );
     }
 
@@ -76,9 +90,7 @@ class FacturXService
 
             $totalHT += $lineTotal;
 
-            $vatRate = isset($product->tva)
-                ? (float)$product->tva
-                : 20.0;
+			$vatRate = $this->getVatRate($product);
 
             $key = number_format($vatRate, 2);
 
@@ -120,9 +132,7 @@ class FacturXService
                 4
             );
 
-            $vatRate = isset($product->tva)
-                ? (float)$product->tva
-                : 20.0;
+			$vatRate = $this->getVatRate($product);
 
             $designation = htmlspecialchars(
                 $product->description
@@ -200,6 +210,11 @@ XML;
         return $xml;
     }
 
+	private function getVatRate(object $product): float
+	{
+		return (float)($product->vat ?? $product->tva ?? 20.0);
+	}
+
     /**
      * Build VAT number
      */
@@ -224,12 +239,15 @@ XML;
     private function buildDocument(
         object $invoice,
         object $company,
+		object $customer,
         DateTime $invoiceDate,
         DateTime $dueDate,
         string $lineItemsXml,
         string $taxXml,
         array $totals,
-        string $sellerVatId
+        string $sellerVatId,
+		string $sellerSiret,
+		string $sellerSiren
     ): string {
 
         $sellerName = htmlspecialchars($company->entreprise ?? '', ENT_XML1);
@@ -255,6 +273,9 @@ XML;
         $buyerVatId = htmlspecialchars(trim($customer->vat_number ?? ''), ENT_XML1);
         $buyerCompanyIdXml = $buyerCompanyId !== '' ? "<ram:ID>{$buyerCompanyId}</ram:ID>" : '';
         $buyerVatIdXml = $buyerVatId !== '' ? "<ram:SpecifiedTaxRegistration><ram:ID schemeID=\"VA\">{$buyerVatId}</ram:ID></ram:SpecifiedTaxRegistration>" : '';
+		$sellerSiretXml = $sellerSiret !== '' ? "<ram:GlobalID schemeID=\"0009\">{$sellerSiret}</ram:GlobalID>" : '';
+		$sellerSirenXml = $sellerSiren !== '' ? "<ram:SpecifiedLegalOrganization><ram:ID schemeID=\"0002\">{$sellerSiren}</ram:ID></ram:SpecifiedLegalOrganization>" : '';
+		$sellerVatIdXml = $sellerVatId !== '' ? "<ram:SpecifiedTaxRegistration><ram:ID schemeID=\"VA\">{$sellerVatId}</ram:ID></ram:SpecifiedTaxRegistration>" : '';
 
         $invoiceNumber = htmlspecialchars($invoice->num, ENT_XML1);
 
@@ -266,6 +287,7 @@ XML;
 
         $invoiceDateFormatted = $invoiceDate->format('Ymd');
         $dueDateFormatted = $dueDate->format('Ymd');
+		$profileId = self::PROFILE_ID;
 
         return <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -279,7 +301,7 @@ XML;
 
     <rsm:ExchangedDocumentContext>
         <ram:GuidelineSpecifiedDocumentContextParameter>
-            <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ram:ID>
+            <ram:ID>{$profileId}</ram:ID>
         </ram:GuidelineSpecifiedDocumentContextParameter>
     </rsm:ExchangedDocumentContext>
 
@@ -302,7 +324,11 @@ XML;
 
             <ram:SellerTradeParty>
 
+				{$sellerSiretXml}
+
                 <ram:Name>{$sellerName}</ram:Name>
+
+				{$sellerSirenXml}
 
                 <ram:PostalTradeAddress>
                     <ram:PostcodeCode>{$sellerZip}</ram:PostcodeCode>
@@ -311,11 +337,7 @@ XML;
                     <ram:CountryID>{$sellerCountry}</ram:CountryID>
                 </ram:PostalTradeAddress>
 
-                <ram:SpecifiedTaxRegistration>
-                    <ram:ID schemeID="VA">
-                        {$sellerVatId}
-                    </ram:ID>
-                </ram:SpecifiedTaxRegistration>
+				{$sellerVatIdXml}
 
             </ram:SellerTradeParty>
 

--- a/lib/Service/PdfService.php
+++ b/lib/Service/PdfService.php
@@ -6,7 +6,6 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 
 use Exception;
 use Mpdf\Mpdf;
-use OCA\Gestion\Controller\GestionFacturXWriter;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\Mail\IMailer;
@@ -17,17 +16,20 @@ class PdfService {
 	private FileService $fileService;
 	private DataService $dataService;
 	private IopoleService $iopoleService;
+	private FacturXService $facturXService;
 
 	public function __construct(
 		IMailer $mailer,
 		FileService $fileService,
 		DataService $dataService,
-		IopoleService $iopoleService
+		IopoleService $iopoleService,
+		FacturXService $facturXService
 	) {
 		$this->mailer = $mailer;
 		$this->fileService = $fileService;
 		$this->dataService = $dataService;
 		$this->iopoleService = $iopoleService;
+		$this->facturXService = $facturXService;
 	}
 
 	public function sendPDF($content, $name, $subject, $body, $to, $Cc): DataResponse {
@@ -133,13 +135,9 @@ class PdfService {
 
 			$pdfContent = $this->renderPdf($html);
 
-			$writer = new GestionFacturXWriter();
-
-			$facturxPdfContent = $writer->generate(
+			$facturxPdfContent = $this->facturXService->generateFacturXPdf(
 				$pdfContent,
-				$facturxXml,
-				null,
-				false
+				$facturxXml
 			);
 
 			$cleanName = html_entity_decode($name);
@@ -267,398 +265,37 @@ class PdfService {
 
 		$pdfContent = $this->renderPdf($html);
 
-		$writer = new GestionFacturXWriter();
-
-		return $writer->generate(
+		return $this->facturXService->generateFacturXPdf(
 			$pdfContent,
-			$facturxXml,
-			null,
-			false
+			$facturxXml
 		);
-	}
-
-	private function formatAmount(float $amount): string {
-		return number_format(round($amount, 2), 2, '.', '');
 	}
 
 	private function buildFacturXml(int $factureId) {
-
 		$factureRows = json_decode(
 			$this->dataService->getOneFacture($factureId)
 		);
-
 		$configRows = json_decode(
 			$this->dataService->getConfiguration()
 		);
 
 		if (empty($factureRows) || empty($configRows)) {
-
 			return new DataResponse([
 				'status' => 'error',
-				'message' => 'Unable to find the invoice or configuration.'
+				'message' => 'Unable to find the invoice or configuration.',
 			], 404);
 		}
 
-		$facture = $factureRows[0];
-		$config = $configRows[0];
-
-		$produitsRows = json_decode(
-			$this->dataService->getProduitsById($facture->id_devis)
+		$invoice = $factureRows[0];
+		$products = json_decode(
+			$this->dataService->getProduitsById($invoice->id_devis)
 		);
 
-		$vatLines = [];
-		$totalHT = 0.0;
-
-		foreach ($produitsRows as $p) {
-
-			$unitPrice = round((float)$p->prix_unitaire, 2);
-			$quantity = round((float)$p->quantite, 2);
-
-			$lineTotal = round($unitPrice * $quantity, 2);
-
-			$totalHT += $lineTotal;
-
-			$vatRate = isset($p->vat)
-				? (float)$p->vat
-				: 20.0;
-
-			$key = number_format($vatRate, 2, '.', '');
-
-			if (!isset($vatLines[$key])) {
-
-				$vatLines[$key] = [
-					'rate' => $vatRate,
-					'base' => 0.0,
-					'amount' => 0.0
-				];
-			}
-
-			$vatLines[$key]['base'] += round($lineTotal, 2);
-
-			$vatLines[$key]['amount'] += round(
-				$lineTotal * $vatRate / 100,
-				2
-			);
-		}
-
-		foreach ($vatLines as &$vl) {
-
-			$vl['base'] = round($vl['base'], 2);
-			$vl['amount'] = round($vl['amount'], 2);
-		}
-
-		unset($vl);
-
-		$totalHT = round($totalHT, 2);
-
-		$totalVAT = round(
-			array_sum(array_column($vatLines, 'amount')),
-			2
+		return $this->facturXService->buildXml(
+			$invoice,
+			$configRows[0],
+			$products ?? [],
+			$invoice
 		);
-
-		$totalTTC = round($totalHT + $totalVAT, 2);
-
-		$invoiceDate = new \DateTime($facture->date);
-
-		$dueDate = new \DateTime($facture->date_paiement);
-
-		$invoiceDateFormatted = $invoiceDate->format('Ymd');
-		$dueDateFormatted = $dueDate->format('Ymd');
-
-        $sellerVatId = htmlspecialchars(
-          trim($config->vat_number ?? ''),
-          ENT_XML1
-        );
-
-		$lineItemsXml = '';
-		$lineNum = 1;
-
-		foreach ($produitsRows as $p) {
-
-			$unitPrice = round((float)$p->prix_unitaire, 2);
-			$quantity = round((float)$p->quantite, 2);
-
-			$lineTotal = round($unitPrice * $quantity, 2);
-
-			$vatRate = isset($p->vat)
-				? (float)$p->vat
-				: 20.0;
-
-			$unitPriceFmt = $this->formatAmount($unitPrice);
-			$lineTotalFmt = $this->formatAmount($lineTotal);
-			$quantityFmt = number_format($quantity, 2, '.', '');
-			$vatRateFmt = number_format($vatRate, 2, '.', '');
-
-			$designation = htmlspecialchars(
-				$p->description ?? $p->reference ?? '',
-				ENT_XML1
-			);
-
-			$lineItemsXml .= <<<XML
-
-<ram:IncludedSupplyChainTradeLineItem>
-
-	<ram:AssociatedDocumentLineDocument>
-		<ram:LineID>{$lineNum}</ram:LineID>
-	</ram:AssociatedDocumentLineDocument>
-
-	<ram:SpecifiedTradeProduct>
-		<ram:Name>{$designation}</ram:Name>
-	</ram:SpecifiedTradeProduct>
-
-	<ram:SpecifiedLineTradeAgreement>
-		<ram:NetPriceProductTradePrice>
-			<ram:ChargeAmount>{$unitPriceFmt}</ram:ChargeAmount>
-		</ram:NetPriceProductTradePrice>
-	</ram:SpecifiedLineTradeAgreement>
-
-	<ram:SpecifiedLineTradeDelivery>
-		<ram:BilledQuantity unitCode="C62">{$quantityFmt}</ram:BilledQuantity>
-	</ram:SpecifiedLineTradeDelivery>
-
-	<ram:SpecifiedLineTradeSettlement>
-
-		<ram:ApplicableTradeTax>
-			<ram:TypeCode>VAT</ram:TypeCode>
-			<ram:CategoryCode>S</ram:CategoryCode>
-			<ram:RateApplicablePercent>{$vatRateFmt}</ram:RateApplicablePercent>
-		</ram:ApplicableTradeTax>
-
-		<ram:SpecifiedTradeSettlementLineMonetarySummation>
-			<ram:LineTotalAmount>{$lineTotalFmt}</ram:LineTotalAmount>
-		</ram:SpecifiedTradeSettlementLineMonetarySummation>
-
-	</ram:SpecifiedLineTradeSettlement>
-
-</ram:IncludedSupplyChainTradeLineItem>
-
-XML;
-
-			$lineNum++;
-		}
-
-		$taxXml = '';
-
-		foreach ($vatLines as $vl) {
-
-			$taxXml .= <<<XML
-
-<ram:ApplicableTradeTax>
-
-	<ram:CalculatedAmount>{$this->formatAmount($vl['amount'])}</ram:CalculatedAmount>
-
-	<ram:TypeCode>VAT</ram:TypeCode>
-
-	<ram:BasisAmount>{$this->formatAmount($vl['base'])}</ram:BasisAmount>
-
-	<ram:CategoryCode>S</ram:CategoryCode>
-
-	<ram:RateApplicablePercent>{$this->formatAmount($vl['rate'])}</ram:RateApplicablePercent>
-
-</ram:ApplicableTradeTax>
-
-XML;
-		}
-
-		$sellerName = htmlspecialchars(
-			$config->entreprise ?? '',
-			ENT_XML1
-		);
-
-		$sellerAddress = htmlspecialchars(
-			$config->adresse ?? '',
-			ENT_XML1
-		);
-
-		$sellerCity = htmlspecialchars(
-			$config->city_name ?? '',
-			ENT_XML1
-		);
-
-		$sellerZip = htmlspecialchars(
-			$config->zip_code ?? '',
-			ENT_XML1
-		);
-
-		$sellerCountry = htmlspecialchars(
-			$config->pays ?? 'FR',
-			ENT_XML1
-		);
-
-		$buyerName = htmlspecialchars(
-			trim(
-				($facture->prenom ?? '') . ' ' .
-				($facture->nom ?? '')
-			),
-			ENT_XML1
-		);
-
-        $buyerAddress = htmlspecialchars($facture->adresse ?? '', ENT_XML1);
-        $buyerZip = htmlspecialchars($facture->zip_code ?? '', ENT_XML1);
-        $buyerCity = htmlspecialchars($facture->city_name ?? '', ENT_XML1);
-        $buyerCountry = htmlspecialchars($facture->country_code ?? 'FR', ENT_XML1);
-        $buyerCompanyId = htmlspecialchars(trim($facture->company_identification ?? ''), ENT_XML1);
-        $buyerVatId = htmlspecialchars(trim($facture->vat_number ?? ''), ENT_XML1);
-        $buyerCompanyIdXml = $buyerCompanyId !== '' ? "<ram:ID>{$buyerCompanyId}</ram:ID>" : '';
-        $buyerVatIdXml = $buyerVatId !== '' ? "<ram:SpecifiedTaxRegistration><ram:ID schemeID=\"VA\">{$buyerVatId}</ram:ID></ram:SpecifiedTaxRegistration>" : '';
-
-		$invoiceNum = htmlspecialchars(
-			$facture->num,
-			ENT_XML1
-		);
-
-		$paymentMeans = htmlspecialchars(
-			$facture->type_paiement ?? '',
-			ENT_XML1
-		);
-
-		$sellerIban = htmlspecialchars(
-			trim($config->iban ?? ''),
-			ENT_XML1
-		);
-
-		$totalHTFmt = $this->formatAmount($totalHT);
-		$totalVATFmt = $this->formatAmount($totalVAT);
-		$totalTTCFmt = $this->formatAmount($totalTTC);
-
-		return <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-
-<rsm:CrossIndustryInvoice
-	xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
-	xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
-	xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
-	xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
-
-	<rsm:ExchangedDocumentContext>
-		<ram:GuidelineSpecifiedDocumentContextParameter>
-			<ram:ID>urn:cen.eu:en16931:2017</ram:ID>
-		</ram:GuidelineSpecifiedDocumentContextParameter>
-	</rsm:ExchangedDocumentContext>
-
-	<rsm:ExchangedDocument>
-
-		<ram:ID>{$invoiceNum}</ram:ID>
-
-		<ram:TypeCode>380</ram:TypeCode>
-
-		<ram:IssueDateTime>
-			<udt:DateTimeString format="102">
-				{$invoiceDateFormatted}
-			</udt:DateTimeString>
-		</ram:IssueDateTime>
-
-	</rsm:ExchangedDocument>
-
-	<rsm:SupplyChainTradeTransaction>
-
-		{$lineItemsXml}
-
-		<ram:ApplicableHeaderTradeAgreement>
-
-			<ram:SellerTradeParty>
-
-				<ram:Name>{$sellerName}</ram:Name>
-
-				<ram:PostalTradeAddress>
-
-					<ram:PostcodeCode>{$sellerZip}</ram:PostcodeCode>
-
-					<ram:LineOne>{$sellerAddress}</ram:LineOne>
-
-					<ram:CityName>{$sellerCity}</ram:CityName>
-
-					<ram:CountryID>{$sellerCountry}</ram:CountryID>
-
-				</ram:PostalTradeAddress>
-
-				<ram:SpecifiedTaxRegistration>
-					<ram:ID schemeID="VA">{$sellerVatId}</ram:ID>
-				</ram:SpecifiedTaxRegistration>
-
-			</ram:SellerTradeParty>
-
-			<ram:BuyerTradeParty>
-
-    {$buyerCompanyIdXml}
-
-    <ram:Name>{$buyerName}</ram:Name>
-
-    <ram:PostalTradeAddress>
-
-        <ram:PostcodeCode>{$buyerZip}</ram:PostcodeCode>
-
-        <ram:LineOne>{$buyerAddress}</ram:LineOne>
-
-        <ram:CityName>{$buyerCity}</ram:CityName>
-
-        <ram:CountryID>{$buyerCountry}</ram:CountryID>
-
-    </ram:PostalTradeAddress>
-
-    {$buyerVatIdXml}
-
-</ram:BuyerTradeParty>
-
-		</ram:ApplicableHeaderTradeAgreement>
-
-		<ram:ApplicableHeaderTradeDelivery/>
-
-		<ram:ApplicableHeaderTradeSettlement>
-
-			<ram:PaymentReference>{$invoiceNum}</ram:PaymentReference>
-
-			<ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
-
-			<ram:SpecifiedTradeSettlementPaymentMeans>
-
-				<ram:TypeCode>58</ram:TypeCode>
-
-				<ram:Information>{$paymentMeans}</ram:Information>
-
-				<ram:PayeePartyCreditorFinancialAccount>
-						<ram:IBANID>{$sellerIban}</ram:IBANID>
-				</ram:PayeePartyCreditorFinancialAccount>
-
-			</ram:SpecifiedTradeSettlementPaymentMeans>
-
-			{$taxXml}
-
-			<ram:SpecifiedTradePaymentTerms>
-
-				<ram:Description>{$paymentMeans}</ram:Description>
-
-				<ram:DueDateDateTime>
-					<udt:DateTimeString format="102">
-						{$dueDateFormatted}
-					</udt:DateTimeString>
-				</ram:DueDateDateTime>
-
-			</ram:SpecifiedTradePaymentTerms>
-
-			<ram:SpecifiedTradeSettlementHeaderMonetarySummation>
-
-				<ram:LineTotalAmount>{$totalHTFmt}</ram:LineTotalAmount>
-
-				<ram:TaxBasisTotalAmount>{$totalHTFmt}</ram:TaxBasisTotalAmount>
-
-				<ram:TaxTotalAmount currencyID="EUR">
-					{$totalVATFmt}
-				</ram:TaxTotalAmount>
-
-				<ram:GrandTotalAmount>{$totalTTCFmt}</ram:GrandTotalAmount>
-
-				<ram:DuePayableAmount>{$totalTTCFmt}</ram:DuePayableAmount>
-
-			</ram:SpecifiedTradeSettlementHeaderMonetarySummation>
-
-		</ram:ApplicableHeaderTradeSettlement>
-
-	</rsm:SupplyChainTradeTransaction>
-
-</rsm:CrossIndustryInvoice>
-
-XML;
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gestion",
-  "version": "3.2.4",
+  "version": "3.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gestion",
-      "version": "3.2.4",
+      "version": "3.2.6",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@nextcloud/browserslist-config": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestion",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "Application pour gérer votre micro entreprise, client, facture, devis",
   "author": "Benjamin AIMARD",
   "contributors": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,9 @@
         <testsuite name="Ihm">
             <directory>./tests/Unit/Ihm</directory>
         </testsuite>
+		<testsuite name="Service">
+			<directory>./tests/Unit/Service</directory>
+		</testsuite>
     </testsuites>
     <php>
         <!-- <server name="KERNEL_CLASS" value="../../vendor/autoload.php" /> -->

--- a/templates/content/changelog.php
+++ b/templates/content/changelog.php
@@ -1,7 +1,7 @@
 <div syle="display: none;" id="modalConfig" class="modal">
 <div class="modal-content">
 	<span class="modalClose">&times;</span>
-	<h2><?php p($l->t('Welcome to GESTION')); ?> 3.2.3</h2>
+	<h2><?php p($l->t('Welcome to GESTION')); ?> 3.2.6</h2>
 
 	<p style="font-size:14px;margin-bottom:20px;">
 		<?php p($l->t(
@@ -47,7 +47,7 @@
 
 	<hr/>
 	<h2><?php p($l->t('Changelog')); ?></h2>
-	<h3>Version 3.2.3</h3>
+	<h3>Version 3.2.6</h3>
 	<p style="font-size:14px;"><?php p($l->t('This version focuses on electronic invoicing and prepares Gestion for the French e-invoicing transition.')); ?></p>
 	<p><a href="https://github.com/baimard/gestion/releases"><?php p($l->t('Releases')); ?></a></p>
 

--- a/templates/modal/configuration_modal.php
+++ b/templates/modal/configuration_modal.php
@@ -15,6 +15,11 @@
         <div class="configuration-global"><label class="configuration" for="city_name"><?php p($l->t('City name'));?></label><input type="text" style="float:none;width:80%;" id="city_name" class="configuration-content editableConfiguration" data-table="configuration" data-column="city_name" data-id="" /></div>
         <div class="configuration-global"><label class="configuration" for="legal_one"><?php p($l->t('Legal One'));?></label><input type="text" style="float:none;width:80%;" id="legal_one" class="configuration-content editableConfiguration" data-table="configuration" data-column="legal_one" data-id="" /></div>
         <div class="configuration-global"><label class="configuration" for="legal_two"><?php p($l->t('Legal Two'));?></label><input type="text" style="float:none;width:80%;" id="legal_two" class="configuration-content editableConfiguration" data-table="configuration" data-column="legal_two" data-id="" /></div>
+        <button
+            type="button"
+            class="electronic-invoice-help"
+            title="<?php p($l->t('Use “SIRET:” in Legal One and “SIREN:” in Legal Two for these identifiers to be included in the electronic invoice.')); ?>"
+        ><?php p($l->t('Electroning invoice')); ?></button>
         <div class="configuration-global"><label class="configuration" for="telephone"><?php p($l->t('Cellphone'));?></label><input type="text" style="float:none;width:80%;" id="telephone" class="configuration-content editableConfiguration" data-table="configuration" data-column="telephone" data-id="" /></div>
         <div class="configuration-global"><label class="configuration" for="mail"><?php p($l->t('Mail'));?></label><input type="text" style="float:none;width:80%;" id="mail" class="configuration-content editableConfiguration" data-table="configuration" data-column="mail" data-id="" /></div>
         <div class="configuration-global"><label class="configuration" for="tva_default"><?php p($l->t('VAT Default'));?></label><input type="number" style="float:none;width:80%;" id="tva_default" class="configuration-content editableConfiguration" data-table="configuration" data-column="tva_default" data-id="" /> %</div>

--- a/tests/Unit/Service/ElectronicInvoiceIdentifiersTest.php
+++ b/tests/Unit/Service/ElectronicInvoiceIdentifiersTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace OCA\Gestion\Tests\Unit\Service;
+
+use OCA\Gestion\Service\ElectronicInvoiceIdentifiers;
+use PHPUnit\Framework\TestCase;
+
+class ElectronicInvoiceIdentifiersTest extends TestCase {
+	public function testExtractsOnlySiretDigits(): void {
+		$this->assertSame(
+			'12345678901234',
+			ElectronicInvoiceIdentifiers::extractDigits('SIRET : 123 456 789 012 34', 'SIRET')
+		);
+	}
+
+	public function testExtractsOnlySirenDigitsCaseInsensitively(): void {
+		$this->assertSame(
+			'123456789',
+			ElectronicInvoiceIdentifiers::extractDigits('siren: 123 456 789', 'SIREN')
+		);
+	}
+
+	public function testIgnoresFieldWithoutExpectedPrefix(): void {
+		$this->assertSame(
+			'',
+			ElectronicInvoiceIdentifiers::extractDigits('RCS : 123 456 789', 'SIRET')
+		);
+	}
+
+	public function testIgnoresAFieldUsingTheOtherIdentifier(): void {
+		$this->assertSame(
+			'',
+			ElectronicInvoiceIdentifiers::extractDigits('SIREN : 123 456 789', 'SIRET')
+		);
+	}
+}

--- a/tests/Unit/Service/FacturXServiceTest.php
+++ b/tests/Unit/Service/FacturXServiceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace OCA\Gestion\Tests\Unit\Service;
+
+use OCA\Gestion\Service\FacturXService;
+use PHPUnit\Framework\TestCase;
+
+class FacturXServiceTest extends TestCase {
+	public function testBuildsOnlyTheEn16931Profile(): void {
+		$service = new FacturXService();
+		$invoice = (object)[
+			'date' => '2026-08-06',
+			'date_paiement' => '2026-09-06',
+			'num' => 'F-1',
+			'type_paiement' => 'bank',
+		];
+		$company = (object)[
+			'entreprise' => 'Gestion',
+			'adresse' => '1 rue de Paris',
+			'zip_code' => '75001',
+			'city_name' => 'Paris',
+		];
+		$products = [(object)[
+			'description' => 'Service',
+			'prix_unitaire' => 100,
+			'quantite' => 1,
+			'vat' => 20,
+		]];
+
+		$xml = $service->buildXml($invoice, $company, $products);
+
+		$this->assertStringContainsString(FacturXService::PROFILE_ID, $xml);
+		$this->assertStringNotContainsString('factur-x.eu:1p0:extended', $xml);
+		$this->assertSame(1, substr_count($xml, '<ram:GuidelineSpecifiedDocumentContextParameter>'));
+	}
+}


### PR DESCRIPTION
### Motivation
- Prepare the app for electronic invoicing (Factur‑X) and include EN16931 profile metadata in generated XML. 
- Extract structured company identifiers (SIRET/SIREN) from freeform legal fields to include them in electronic invoices. 
- Centralize Factur‑X generation logic and simplify `PdfService` by delegating to a dedicated service. 

### Description
- Add `ElectronicInvoiceIdentifiers` service with `extractDigits` to parse and return only digits for prefixed identifiers like `SIRET:` and `SIREN:`. 
- Extend `FacturXService` to build EN16931 XML, include seller `SIRET`/`SIREN` and VAT elements, expose `PROFILE_ID`, and factor VAT handling via `getVatRate`. 
- Refactor `PdfService` to depend on `FacturXService` for generating Factur‑X PDFs and for building XML, removing inlined Factur‑X generation code. 
- Add UI pieces: button and styles for electronic invoice help in the configuration modal, update changelog modal version text, and bump app/package versions. 
- Update `phpunit.xml` to include a `Service` testsuite and add unit tests `ElectronicInvoiceIdentifiersTest` and `FacturXServiceTest`. 

### Testing
- Ran the PHPUnit suite including the new `Service` testsuite with `ElectronicInvoiceIdentifiersTest` and `FacturXServiceTest`, and all tests passed. 
- Verified that Factur‑X XML output includes the EN16931 `PROFILE_ID` and no longer contains the previous `factur-x.eu:1p0:extended` marker. 
- No automated UI/browser tests were modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a742a2137bc83329d0bb35cf746c953)