### PR TITLE
Emit qualified French SIREN/SIRET identifiers in FacturX XML and add identifier helpers/tests

### DIFF
--- a/lib/Service/ElectronicInvoiceIdentifiers.php
+++ b/lib/Service/ElectronicInvoiceIdentifiers.php
@@ -10,4 +10,24 @@ final class ElectronicInvoiceIdentifiers {
 
 		return preg_replace('/\D+/', '', $matches[1]);
 	}
+
+	public static function sirenFrom(string $value): string {
+		$digits = preg_replace('/\D+/', '', $value);
+
+		if (strlen($digits) === 14) {
+			$digits = substr($digits, 0, 9);
+		}
+
+		return self::isUsableIdentifier($digits, 9) ? $digits : '';
+	}
+
+	public static function siretFrom(string $value): string {
+		$digits = preg_replace('/\D+/', '', $value);
+
+		return self::isUsableIdentifier($digits, 14) ? $digits : '';
+	}
+
+	private static function isUsableIdentifier(string $digits, int $length): bool {
+		return strlen($digits) === $length && preg_match('/[1-9]/', $digits) === 1;
+	}
 }

--- a/lib/Service/FacturXService.php
+++ b/lib/Service/FacturXService.php
@@ -58,6 +58,11 @@ class FacturXService
 			(string)($company->legal_two ?? ''),
 			'SIREN'
 		);
+		$sellerSiret = ElectronicInvoiceIdentifiers::siretFrom($sellerSiret);
+		$sellerSiren = ElectronicInvoiceIdentifiers::sirenFrom($sellerSiren);
+		if ($sellerSiren === '') {
+			$sellerSiren = ElectronicInvoiceIdentifiers::sirenFrom($sellerSiret);
+		}
 
         return $this->buildDocument(
             invoice: $invoice,
@@ -269,9 +274,12 @@ XML;
         $buyerZip = htmlspecialchars($customer->zip_code ?? '', ENT_XML1);
         $buyerCity = htmlspecialchars($customer->city_name ?? '', ENT_XML1);
         $buyerCountry = htmlspecialchars($customer->country_code ?? 'FR', ENT_XML1);
-        $buyerCompanyId = htmlspecialchars(trim($customer->company_identification ?? ''), ENT_XML1);
-        $buyerVatId = htmlspecialchars(trim($customer->vat_number ?? ''), ENT_XML1);
-        $buyerCompanyIdXml = $buyerCompanyId !== '' ? "<ram:ID>{$buyerCompanyId}</ram:ID>" : '';
+		$buyerCompanyId = trim($customer->company_identification ?? '');
+		$buyerVatId = htmlspecialchars(trim($customer->vat_number ?? ''), ENT_XML1);
+		$buyerSiret = ElectronicInvoiceIdentifiers::siretFrom($buyerCompanyId);
+		$buyerSiren = ElectronicInvoiceIdentifiers::sirenFrom($buyerCompanyId);
+		$buyerSiretXml = $buyerSiret !== '' ? "<ram:GlobalID schemeID=\"0009\">{$buyerSiret}</ram:GlobalID>" : '';
+		$buyerSirenXml = $buyerSiren !== '' ? "<ram:SpecifiedLegalOrganization><ram:ID schemeID=\"0002\">{$buyerSiren}</ram:ID></ram:SpecifiedLegalOrganization>" : '';
         $buyerVatIdXml = $buyerVatId !== '' ? "<ram:SpecifiedTaxRegistration><ram:ID schemeID=\"VA\">{$buyerVatId}</ram:ID></ram:SpecifiedTaxRegistration>" : '';
 		$sellerSiretXml = $sellerSiret !== '' ? "<ram:GlobalID schemeID=\"0009\">{$sellerSiret}</ram:GlobalID>" : '';
 		$sellerSirenXml = $sellerSiren !== '' ? "<ram:SpecifiedLegalOrganization><ram:ID schemeID=\"0002\">{$sellerSiren}</ram:ID></ram:SpecifiedLegalOrganization>" : '';
@@ -343,9 +351,11 @@ XML;
 
             <ram:BuyerTradeParty>
 
-    {$buyerCompanyIdXml}
+	    {$buyerSiretXml}
 
-    <ram:Name>{$buyerName}</ram:Name>
+	    <ram:Name>{$buyerName}</ram:Name>
+
+	    {$buyerSirenXml}
 
     <ram:PostalTradeAddress>
 

--- a/tests/Unit/Service/ElectronicInvoiceIdentifiersTest.php
+++ b/tests/Unit/Service/ElectronicInvoiceIdentifiersTest.php
@@ -33,4 +33,18 @@ class ElectronicInvoiceIdentifiersTest extends TestCase {
 			ElectronicInvoiceIdentifiers::extractDigits('SIREN : 123 456 789', 'SIRET')
 		);
 	}
+
+	public function testBuildsSirenFromSirenOrSiret(): void {
+		$this->assertSame('493845341', ElectronicInvoiceIdentifiers::sirenFrom('493845341'));
+		$this->assertSame('493845341', ElectronicInvoiceIdentifiers::sirenFrom('493 845 341 00038'));
+	}
+
+	public function testRejectsAnAllZeroSiren(): void {
+		$this->assertSame('', ElectronicInvoiceIdentifiers::sirenFrom('000000000'));
+	}
+
+	public function testBuildsOnlyFourteenDigitSiret(): void {
+		$this->assertSame('49384534100038', ElectronicInvoiceIdentifiers::siretFrom('493 845 341 00038'));
+		$this->assertSame('', ElectronicInvoiceIdentifiers::siretFrom('493845341'));
+	}
 }

--- a/tests/Unit/Service/FacturXServiceTest.php
+++ b/tests/Unit/Service/FacturXServiceTest.php
@@ -33,4 +33,65 @@ class FacturXServiceTest extends TestCase {
 		$this->assertStringNotContainsString('factur-x.eu:1p0:extended', $xml);
 		$this->assertSame(1, substr_count($xml, '<ram:GuidelineSpecifiedDocumentContextParameter>'));
 	}
+
+	public function testBuildsQualifiedFrenchSellerAndBuyerIdentifiers(): void {
+		$service = new FacturXService();
+		$invoice = (object)[
+			'date' => '2026-08-06',
+			'date_paiement' => '2026-09-06',
+			'num' => 'F-2',
+			'type_paiement' => 'bank',
+			'nom' => 'Client',
+			'prenom' => 'Test',
+		];
+		$company = (object)[
+			'entreprise' => 'Gestion',
+			'adresse' => '1 rue de Paris',
+			'zip_code' => '75001',
+			'city_name' => 'Paris',
+			'legal_one' => 'SIRET: 89157747000034',
+			'legal_two' => 'SIREN: 000000000',
+		];
+		$customer = (object)[
+			'company_identification' => '493845341',
+		];
+		$products = [(object)[
+			'description' => 'Service',
+			'prix_unitaire' => 100,
+			'quantite' => 1,
+			'vat' => 20,
+		]];
+
+		$xml = $service->buildXml($invoice, $company, $products, $customer);
+
+		$this->assertStringContainsString('<ram:GlobalID schemeID="0009">89157747000034</ram:GlobalID>', $xml);
+		$this->assertStringContainsString('<ram:ID schemeID="0002">891577470</ram:ID>', $xml);
+		$this->assertStringContainsString('<ram:ID schemeID="0002">493845341</ram:ID>', $xml);
+		$this->assertStringNotContainsString('<ram:ID>493845341</ram:ID>', $xml);
+		$this->assertStringNotContainsString('000000000', $xml);
+	}
+
+	public function testBuildsBuyerSiretAndDerivesItsSiren(): void {
+		$service = new FacturXService();
+		$invoice = (object)[
+			'date' => '2026-08-06',
+			'date_paiement' => '2026-09-06',
+			'num' => 'F-3',
+		];
+		$company = (object)[];
+		$customer = (object)[
+			'company_identification' => '493 845 341 00038',
+		];
+		$products = [(object)[
+			'description' => 'Service',
+			'prix_unitaire' => 100,
+			'quantite' => 1,
+			'vat' => 20,
+		]];
+
+		$xml = $service->buildXml($invoice, $company, $products, $customer);
+
+		$this->assertStringContainsString('<ram:GlobalID schemeID="0009">49384534100038</ram:GlobalID>', $xml);
+		$this->assertStringContainsString('<ram:ID schemeID="0002">493845341</ram:ID>', $xml);
+	}
 }


### PR DESCRIPTION
### Motivation

- Ensure SIRET and SIREN values included in generated FacturX XML are properly parsed, validated and emitted using the correct qualified elements and scheme identifiers.

### Description

- Add `ElectronicInvoiceIdentifiers::sirenFrom`, `::siretFrom` and `::isUsableIdentifier` to normalize and validate French SIREN/SIRET digit strings.
- Update `FacturXService::buildXml` to use the new identifier helpers to populate qualified XML nodes for seller and buyer (`ram:GlobalID schemeID="0009"` for SIRET and `ram:SpecifiedLegalOrganization`/`ram:ID schemeID="0002"` for SIREN) instead of raw, unqualified identifiers. 
- Replace the old buyer company identification handling to derive and emit both `buyerSiret` and `buyerSiren` when available and avoid emitting all-zero or invalid identifiers.
- Add unit tests for the identifier helpers and updated XML output in `tests/Unit/Service/ElectronicInvoiceIdentifiersTest.php` and `tests/Unit/Service/FacturXServiceTest.php`.

### Testing

- Ran the unit test suite with `vendor/bin/phpunit` and the added tests for `ElectronicInvoiceIdentifiers` and `FacturXService` executed successfully.
- Verified the new tests `testBuildsQualifiedFrenchSellerAndBuyerIdentifiers` and `testBuildsBuyerSiretAndDerivesItsSiren` pass and assert the presence/absence of the expected qualified XML fragments.
- Existing FacturX profile and XML structure assertions remain covered by the existing tests and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7468f3b8fc8332a98d38533ea6e290)