### PR TITLE
Add VAT category support for products and Factur‑X (migration, UI, service)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@ If you require adaptations to comply with your country's regulations, please ope
 [![Donate](https://img.shields.io/badge/Donate-Buy%20me%20a%20coffee-yellow.svg)](https://www.buymeacoffee.com/benjaminaimard)
 
 ]]></description>
-    <version>3.2.6</version>
+    <version>3.2.7</version>
     <licence>agpl</licence>
     <author mail="benjamin@cybercorp.fr" homepage="https://github.com/baimard">Benjamin AIMARD</author>
     <namespace>Gestion</namespace>

--- a/lib/Db/Bdd.php
+++ b/lib/Db/Bdd.php
@@ -14,7 +14,7 @@ class Bdd {
 
     public function __construct(IDbConnection $db,
                                 IL10N $l) {
-        $this->whiteColumn = array("date", "num", "id_client", "entreprise", "nom", "prenom", "legal_one", "telephone", "mail", "adresse", "produit_id", "quantite", "date_paiement", "type_paiement", "id_devis", "reference", "description", "prix_unitaire", "legal_two", "path", "tva_default", "mentions_default", "version", "mentions", "comment", "status_paiement", "devise", "auto_invoice_number", "changelog", "format", "comment", "user_id", "facture_prefixe", "id_configuration", "delay", "header","vat", "vat_number", "zip_code", "city_name", "country_code","iban", "company_identification" );
+        $this->whiteColumn = array("date", "num", "id_client", "entreprise", "nom", "prenom", "legal_one", "telephone", "mail", "adresse", "produit_id", "quantite", "date_paiement", "type_paiement", "id_devis", "reference", "description", "prix_unitaire", "legal_two", "path", "tva_default", "mentions_default", "version", "mentions", "comment", "status_paiement", "devise", "auto_invoice_number", "changelog", "format", "comment", "user_id", "facture_prefixe", "id_configuration", "delay", "header","vat", "vat_category", "vat_number", "zip_code", "city_name", "country_code","iban", "company_identification" );
         $this->whiteTable = array("client", "devis", "produit_devis", "facture", "produit", "configuration");
         $this->tableprefix = '*PREFIX*' ."gestion_";
         $this->pdo = $db;
@@ -82,7 +82,7 @@ class Bdd {
     }
 
     public function getListProduit($numdevis, $idNextcloud){
-        $sql = "SELECT ".$this->tableprefix."produit.id as pid,".$this->tableprefix."produit_devis.id as pdid, header, reference, description,".$this->tableprefix."produit.vat as vat,".$this->tableprefix."produit_devis.comment, quantite, prix_unitaire FROM ".$this->tableprefix."produit, ".$this->tableprefix."devis, ".$this->tableprefix."produit_devis WHERE ".$this->tableprefix."produit.id = produit_id AND ".$this->tableprefix."devis.id = devis_id AND ".$this->tableprefix."devis.id = ? AND ".$this->tableprefix."devis.id_configuration = ? AND ".$this->tableprefix."produit.id_configuration = ? ORDER BY `oc_gestion_produit_devis`.`order` ASC";
+        $sql = "SELECT ".$this->tableprefix."produit.id as pid,".$this->tableprefix."produit_devis.id as pdid, header, reference, description,".$this->tableprefix."produit.vat as vat,".$this->tableprefix."produit.vat_category as vat_category,".$this->tableprefix."produit_devis.comment, quantite, prix_unitaire FROM ".$this->tableprefix."produit, ".$this->tableprefix."devis, ".$this->tableprefix."produit_devis WHERE ".$this->tableprefix."produit.id = produit_id AND ".$this->tableprefix."devis.id = devis_id AND ".$this->tableprefix."devis.id = ? AND ".$this->tableprefix."devis.id_configuration = ? AND ".$this->tableprefix."produit.id_configuration = ? ORDER BY `oc_gestion_produit_devis`.`order` ASC";
         return $this->execSQL($sql, array($numdevis, $idNextcloud, $idNextcloud));
     }
 
@@ -180,13 +180,15 @@ class Bdd {
             array($idNextcloud)
         )[0]['tva_default'];
 
-        $sql = "INSERT INTO `".$this->tableprefix."produit` (`id_configuration`,`reference`,`description`,`prix_unitaire`,`vat`) VALUES (?,?,?,0,?);";
+        $vatCategory = (float)$vat === 0.0 ? 'E' : 'S';
+        $sql = "INSERT INTO `".$this->tableprefix."produit` (`id_configuration`,`reference`,`description`,`prix_unitaire`,`vat`,`vat_category`) VALUES (?,?,?,0,?,?);";
 
         $this->execSQLNoData($sql, array(
             $idNextcloud,
             $this->l->t('Reference'),
             $this->l->t('Designation'),
-            $vat
+            $vat,
+            $vatCategory
         ));
 
         return true;
@@ -237,6 +239,11 @@ class Bdd {
     }
 
     private function normalizeColumnData($column, $data){
+		if ($column === 'vat_category') {
+			$category = strtoupper(trim($data));
+			return in_array($category, ['S', 'E', 'Z', 'O', 'AE', 'G', 'K'], true) ? $category : 'S';
+		}
+
         if ($column === 'zip_code') {
             return substr($data, 0, 20);
         }

--- a/lib/Migration/Version31202Date20260806120000.php
+++ b/lib/Migration/Version31202Date20260806120000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Gestion\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version31202Date20260806120000 extends SimpleMigrationStep {
+	public function __construct(private IDBConnection $connection) {
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+		$table = $schema->getTable('gestion_produit');
+
+		if (!$table->hasColumn('vat_category')) {
+			$table->addColumn('vat_category', 'string', [
+				'length' => 2,
+				'notnull' => true,
+				'default' => 'S',
+			]);
+		}
+
+		return $schema;
+	}
+
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$query = $this->connection->getQueryBuilder();
+		$query->update('gestion_produit')
+			->set('vat_category', $query->createNamedParameter('E'))
+			->where($query->expr()->eq('vat', $query->createNamedParameter(0)))
+			->executeStatement();
+	}
+}

--- a/lib/Service/FacturXService.php
+++ b/lib/Service/FacturXService.php
@@ -8,6 +8,8 @@ use OCA\Gestion\Controller\GestionFacturXWriter;
 class FacturXService
 {
 	public const PROFILE_ID = 'urn:cen.eu:en16931:2017';
+	private const VAT_EXEMPTION_REASON = 'TVA non applicable, art. 293 B du CGI';
+	private const VAT_CATEGORIES = ['S', 'E', 'Z', 'O', 'AE', 'G', 'K'];
 
     /**
      * Generate complete Factur-X PDF
@@ -96,12 +98,14 @@ class FacturXService
             $totalHT += $lineTotal;
 
 			$vatRate = $this->getVatRate($product);
+			$vatCategory = $this->getVatCategory($product, $vatRate);
 
-            $key = number_format($vatRate, 2);
+            $key = $vatCategory . ':' . number_format($vatRate, 2);
 
             if (!isset($vatLines[$key])) {
                 $vatLines[$key] = [
                     'rate' => $vatRate,
+					'category' => $vatCategory,
                     'base' => 0.0,
                     'amount' => 0.0
                 ];
@@ -138,6 +142,7 @@ class FacturXService
             );
 
 			$vatRate = $this->getVatRate($product);
+			$vatCategory = $this->getVatCategory($product, $vatRate);
 
             $designation = htmlspecialchars(
                 $product->description
@@ -172,7 +177,7 @@ class FacturXService
     <ram:SpecifiedLineTradeSettlement>
         <ram:ApplicableTradeTax>
             <ram:TypeCode>VAT</ram:TypeCode>
-            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:CategoryCode>{$vatCategory}</ram:CategoryCode>
             <ram:RateApplicablePercent>{$vatRate}</ram:RateApplicablePercent>
         </ram:ApplicableTradeTax>
 
@@ -198,15 +203,23 @@ XML;
         $xml = '';
 
         foreach ($vatLines as $vat) {
+			$amount = number_format($vat['amount'], 2, '.', '');
+			$basis = number_format($vat['base'], 2, '.', '');
+			$rate = $vat['rate'];
+			$category = $vat['category'];
+			$exemptionReason = $category === 'E'
+				? "\n    <ram:ExemptionReason>" . self::VAT_EXEMPTION_REASON . '</ram:ExemptionReason>'
+				: '';
 
             $xml .= <<<XML
 
 <ram:ApplicableTradeTax>
-    <ram:CalculatedAmount>{$vat['amount']}</ram:CalculatedAmount>
+    <ram:CalculatedAmount>{$amount}</ram:CalculatedAmount>
     <ram:TypeCode>VAT</ram:TypeCode>
-    <ram:BasisAmount>{$vat['base']}</ram:BasisAmount>
-    <ram:CategoryCode>S</ram:CategoryCode>
-    <ram:RateApplicablePercent>{$vat['rate']}</ram:RateApplicablePercent>
+    {$exemptionReason}
+    <ram:BasisAmount>{$basis}</ram:BasisAmount>
+    <ram:CategoryCode>{$category}</ram:CategoryCode>
+    <ram:RateApplicablePercent>{$rate}</ram:RateApplicablePercent>
 </ram:ApplicableTradeTax>
 
 XML;
@@ -218,6 +231,17 @@ XML;
 	private function getVatRate(object $product): float
 	{
 		return (float)($product->vat ?? $product->tva ?? 20.0);
+	}
+
+	private function getVatCategory(object $product, float $vatRate): string
+	{
+		$category = strtoupper(trim((string)($product->vat_category ?? '')));
+		if (in_array($category, self::VAT_CATEGORIES, true)) {
+			return $category;
+		}
+
+		// Backward compatibility for products created before categories were stored.
+		return $vatRate == 0.0 ? 'E' : 'S';
 	}
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestion",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "Application pour gérer votre micro entreprise, client, facture, devis",
   "author": "Benjamin AIMARD",
   "contributors": [

--- a/src/css/mycss.less
+++ b/src/css/mycss.less
@@ -15,6 +15,23 @@
   background-color: var(--color-main-background);
 }
 
+.vat-category-select {
+  min-width: 12rem;
+}
+
+button.vat-category-help {
+  min-width: 30px;
+  min-height: 30px;
+  margin: 0 0 0 4px;
+  padding: 2px;
+  border-radius: 50%;
+  vertical-align: middle;
+}
+
+button.vat-category-help .material-symbols {
+  font-size: 20px;
+}
+
 table.dataTable.display tbody tr.odd > [class*="sorting_"] {
   background-color: var(--color-main-background);
 }

--- a/src/js/objects/produit.js
+++ b/src/js/objects/produit.js
@@ -1,6 +1,17 @@
 import { showError } from "@nextcloud/dialogs";
 import { baseUrl, cur, LoadDT, showDone } from "../modules/mainFunction.js";
 import { setCsrfRequestHeader } from "../modules/csrf.js";
+import { translate as t } from '@nextcloud/l10n';
+
+const VAT_CATEGORIES = [
+  ['S', 'S — ' + t('gestion', 'Subject to VAT')],
+  ['E', 'E — ' + t('gestion', 'VAT exempt')],
+  ['Z', 'Z — ' + t('gestion', 'Taxable at zero rate')],
+  ['O', 'O — ' + t('gestion', 'Outside the scope of VAT')],
+  ['AE', 'AE — ' + t('gestion', 'Reverse charge')],
+  ['G', 'G — ' + t('gestion', 'Export outside the EU')],
+  ['K', 'K — ' + t('gestion', 'Intra-Community supply')],
+];
 
 export class Produit {
 
@@ -14,6 +25,7 @@ export class Produit {
     this.description = ((myresp.description.length === 0) ? '-' : myresp.description);
     this.prix_unitaire = ((myresp.prix_unitaire.length === 0) ? '-' : myresp.prix_unitaire);
     this.vat = myresp.vat ?? '-';
+    this.vat_category = myresp.vat_category ?? (Number(this.vat) === 0 ? 'E' : 'S');
     this.header = myresp.header;
   }
 
@@ -21,11 +33,15 @@ export class Produit {
    * Get datatable row for a product
    */
   getDTRow() {
+    const vatCategoryOptions = VAT_CATEGORIES.map(([value, label]) =>
+      '<option value="' + value + '"' + (value === this.vat_category ? ' selected' : '') + '>' + label + '</option>'
+    ).join('');
     let myrow = [
       '<div class="editable" data-table="produit" data-column="reference" data-id="' + this.id + '">' + this.reference + '</div>',
       '<div class="editable" data-table="produit" data-column="description" data-id="' + this.id + '">' + this.description + '</div>',
       '<div class="editableNumeric" data-table="produit" data-column="prix_unitaire" data-id="' + this.id + '">' + cur.format(this.prix_unitaire) + '</div>',
       '<div class="editable" data-table="produit" data-column="vat" data-id="' + this.id + '">' + this.vat + '%</div>',
+      '<select class="editableSelect vat-category-select" data-table="produit" data-column="vat_category" data-id="' + this.id + '" aria-label="' + t('gestion', 'Electronic invoice VAT category') + '">' + vatCategoryOptions + '</select>',
       '<div class="editable" data-table="produit" data-column="header" data-id="' + this.id + '">' + this.header + '</div>',
       '<div data-modifier="produit" data-id=' + this.id + ' data-table="produit" style="display:inline-block;margin-right:0px;" class="deleteItem icon-delete"></div>',
     ];

--- a/src/js/produit.js
+++ b/src/js/produit.js
@@ -6,9 +6,15 @@ import DataTable from "datatables.net";
 import { globalConfiguration, optionDatatable } from "./modules/mainFunction.js";
 import "./listener/main_listener";
 import { Produit } from "./objects/produit.js";
+import { showMessage } from "@nextcloud/dialogs";
+import { translate as t } from '@nextcloud/l10n';
 
 window.addEventListener("DOMContentLoaded", function () {
     globalConfiguration();
 
     Produit.loadProduitDT(new DataTable(".tabledt",optionDatatable));
+
+    document.getElementById('vatCategoryHelp')?.addEventListener('click', () => {
+        showMessage(t('gestion', 'France only: this category describes why VAT applies or does not apply in the Factur-X electronic invoice. Choose S for VAT at 5.5%, 10% or 20%; E for the French small-business exemption (article 293 B); Z only for a legally zero-rated taxable supply; O for an operation outside the scope of VAT; AE for reverse charge; G for export outside the EU; or K for an intra-Community supply.'));
+    });
 });

--- a/templates/content/produit.php
+++ b/templates/content/produit.php
@@ -13,6 +13,12 @@
                 <th><?php p($l->t('Designation'));?></th>
                 <th><?php p($l->t('Unit price without VAT'));?></th>
                 <th><?php p($l->t('VAT percentage'));?></th>
+                <th>
+					<?php p($l->t('VAT category (France only)'));?>
+					<button type="button" id="vatCategoryHelp" class="vat-category-help" aria-label="<?php p($l->t('Explain VAT categories'));?>" title="<?php p($l->t('Explain VAT categories'));?>">
+						<span class="material-symbols" aria-hidden="true">help</span>
+					</button>
+				</th>
                 <th><?php p($l->t('Header'));?></th>
                 <th><?php p($l->t('Actions'));?></th>
             </tr>

--- a/tests/Unit/Service/FacturXServiceTest.php
+++ b/tests/Unit/Service/FacturXServiceTest.php
@@ -94,4 +94,57 @@ class FacturXServiceTest extends TestCase {
 		$this->assertStringContainsString('<ram:GlobalID schemeID="0009">49384534100038</ram:GlobalID>', $xml);
 		$this->assertStringContainsString('<ram:ID schemeID="0002">493845341</ram:ID>', $xml);
 	}
+
+	public function testBuildsEveryProductVatBreakdownAndTotalsIncludingTax(): void {
+		$service = new FacturXService();
+		$invoice = (object)[
+			'date' => '2026-07-25',
+			'date_paiement' => '2026-08-25',
+			'num' => 'FACTURE-10',
+		];
+		$products = [
+			(object)['description' => 'Produit sans TVA', 'prix_unitaire' => 10, 'quantite' => 1, 'vat' => 0, 'vat_category' => 'E'],
+			(object)['description' => 'Produit 1', 'prix_unitaire' => 10, 'quantite' => 1, 'vat' => 5.5, 'vat_category' => 'S'],
+			(object)['description' => 'Produit 2', 'prix_unitaire' => 20, 'quantite' => 1, 'vat' => 10, 'vat_category' => 'S'],
+			(object)['description' => 'Produit 3', 'prix_unitaire' => 30, 'quantite' => 1, 'vat' => 20, 'vat_category' => 'S'],
+		];
+
+		$xml = $service->buildXml($invoice, (object)[], $products);
+
+		$this->assertSame(4, substr_count($xml, '<ram:IncludedSupplyChainTradeLineItem>'));
+		foreach ($products as $index => $product) {
+			$this->assertStringContainsString('<ram:LineID>' . ($index + 1) . '</ram:LineID>', $xml);
+			$this->assertStringContainsString('<ram:Name>' . $product->description . '</ram:Name>', $xml);
+			$this->assertStringContainsString('<ram:RateApplicablePercent>' . $product->vat . '</ram:RateApplicablePercent>', $xml);
+		}
+		$this->assertStringContainsString('<ram:CategoryCode>E</ram:CategoryCode>', $xml);
+		$this->assertStringContainsString('<ram:ExemptionReason>TVA non applicable, art. 293 B du CGI</ram:ExemptionReason>', $xml);
+		$this->assertStringNotContainsString('<ram:CategoryCode>Z</ram:CategoryCode>', $xml);
+		$this->assertStringContainsString('<ram:LineTotalAmount>70.00</ram:LineTotalAmount>', $xml);
+		$this->assertStringContainsString('<ram:TaxBasisTotalAmount>70.00</ram:TaxBasisTotalAmount>', $xml);
+		$this->assertStringContainsString('<ram:TaxTotalAmount currencyID="EUR">8.55</ram:TaxTotalAmount>', $xml);
+		$this->assertStringContainsString('<ram:GrandTotalAmount>78.55</ram:GrandTotalAmount>', $xml);
+		$this->assertStringContainsString('<ram:DuePayableAmount>78.55</ram:DuePayableAmount>', $xml);
+	}
+
+	public function testUsesTheCategorySelectedForEachProduct(): void {
+		$service = new FacturXService();
+		$invoice = (object)[
+			'date' => '2026-08-06',
+			'date_paiement' => '2026-09-06',
+			'num' => 'F-4',
+		];
+		$products = [
+			(object)['description' => 'Exonéré', 'prix_unitaire' => 10, 'quantite' => 1, 'vat' => 0, 'vat_category' => 'E'],
+			(object)['description' => 'Taux zéro', 'prix_unitaire' => 20, 'quantite' => 1, 'vat' => 0, 'vat_category' => 'Z'],
+		];
+
+		$xml = $service->buildXml($invoice, (object)[], $products);
+
+		$this->assertSame(2, substr_count($xml, '<ram:CategoryCode>E</ram:CategoryCode>'));
+		$this->assertSame(2, substr_count($xml, '<ram:CategoryCode>Z</ram:CategoryCode>'));
+		$this->assertSame(2, substr_count($xml, '<ram:BasisAmount>'));
+		$this->assertStringContainsString('<ram:BasisAmount>10.00</ram:BasisAmount>', $xml);
+		$this->assertStringContainsString('<ram:BasisAmount>20.00</ram:BasisAmount>', $xml);
+	}
 }


### PR DESCRIPTION
### Motivation
- Introduce explicit VAT category handling for products to support Factur‑X requirements (France-specific categories and exemption reason) and to keep backward compatibility with existing products.
- Persist and expose a `vat_category` column so electronic invoices can include the proper `CategoryCode` and exemption information.

### Description
- Add a migration `Version31202Date20260806120000.php` that creates a `vat_category` column on `gestion_produit` and backfills `'E'` for products with `vat = 0`.
- Extend the database layer in `lib/Db/Bdd.php` to whitelist `vat_category`, return it in product queries and set a default when inserting products, and validate `vat_category` in `normalizeColumnData`.
- Enhance Factur‑X generation in `lib/Service/FacturXService.php` to group VAT lines by `vat_category` and rate, include `CategoryCode` per line, emit an `ExemptionReason` when category `E` is used, and add helpers `getVatCategory` and `getVatRate`.
- Update front-end product UI and assets: add a `vat_category` select with localized labels in `src/js/objects/produit.js`, a help button and listener in `src/js/produit.js`, template changes in `templates/content/produit.php`, styles in `src/css/mycss.less`, and ensure the DataTable renders the new field.
- Bump package and app version numbers in `package.json` and `appinfo/info.xml`.
- Add unit tests in `tests/Unit/Service/FacturXServiceTest.php` to validate line items, VAT breakdown, totals and use of categories.

### Testing
- Ran unit tests with `phpunit tests/Unit --testdox`, including the updated `FacturXServiceTest`, and all tests passed.
- Ran the migration to add `vat_category` and executed the post-schema update SQL which sets category `E` where `vat = 0` in a test database and verified the column and values were created successfully.
- Built frontend assets and loaded the product list UI to verify the new `vat_category` select and help dialog render and send updates; no runtime JS errors were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7470e3d40c83328153030723c9260b)