### PR TITLE
Add structured payment means support (codes + IBAN) and UI selector for invoices

### DIFF
--- a/lib/Service/FacturXService.php
+++ b/lib/Service/FacturXService.php
@@ -10,6 +10,13 @@ class FacturXService
 	public const PROFILE_ID = 'urn:cen.eu:en16931:2017';
 	private const VAT_EXEMPTION_REASON = 'TVA non applicable, art. 293 B du CGI';
 	private const VAT_CATEGORIES = ['S', 'E', 'Z', 'O', 'AE', 'G', 'K'];
+	private const PAYMENT_MEANS = [
+		'10' => 'Cash',
+		'20' => 'Cheque',
+		'30' => 'Credit transfer',
+		'48' => 'Payment card',
+		'58' => 'SEPA credit transfer',
+	];
 
     /**
      * Generate complete Factur-X PDF
@@ -311,7 +318,12 @@ XML;
 
         $invoiceNumber = htmlspecialchars($invoice->num, ENT_XML1);
 
-        $paymentMethod = htmlspecialchars($invoice->type_paiement ?? '', ENT_XML1);
+		$paymentCode = $this->getPaymentMeansCode((string)($invoice->type_paiement ?? ''));
+		$paymentMethod = self::PAYMENT_MEANS[$paymentCode] ?? '';
+		$paymentMeansXml = $this->buildPaymentMeans($paymentCode, (string)($company->iban ?? ''));
+		$paymentDescriptionXml = $paymentMethod !== ''
+			? "<ram:Description>{$paymentMethod}</ram:Description>"
+			: '';
 
         $totalHT = number_format($totals['totalHT'], 2, '.', '');
         $totalVAT = number_format($totals['totalVAT'], 2, '.', '');
@@ -399,24 +411,18 @@ XML;
 
         </ram:ApplicableHeaderTradeAgreement>
 
-        <ram:ApplicableHeaderTradeDelivery/>
-
         <ram:ApplicableHeaderTradeSettlement>
 
             <ram:PaymentReference>{$invoiceNumber}</ram:PaymentReference>
 
-            <ram:TaxCurrencyCode>EUR</ram:TaxCurrencyCode>
             <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
 
-            <ram:SpecifiedTradeSettlementPaymentMeans>
-                <ram:TypeCode>58</ram:TypeCode>
-                <ram:Information>{$paymentMethod}</ram:Information>
-            </ram:SpecifiedTradeSettlementPaymentMeans>
+            {$paymentMeansXml}
 
             {$taxXml}
 
             <ram:SpecifiedTradePaymentTerms>
-                <ram:Description>{$paymentMethod}</ram:Description>
+                {$paymentDescriptionXml}
 
                 <ram:DueDateDateTime>
                     <udt:DateTimeString format="102">
@@ -443,4 +449,51 @@ XML;
 </rsm:CrossIndustryInvoice>
 XML;
     }
+
+	private function getPaymentMeansCode(string $paymentMethod): string
+	{
+		$paymentMethod = trim($paymentMethod);
+		if (isset(self::PAYMENT_MEANS[$paymentMethod])) {
+			return $paymentMethod;
+		}
+
+		$legacyMethods = [
+			'cash' => '10',
+			'cheque' => '20',
+			'check' => '20',
+			'bank' => '30',
+			'credit transfer' => '30',
+			'card' => '48',
+			'payment card' => '48',
+			'sepa credit transfer' => '58',
+		];
+
+		return $legacyMethods[strtolower($paymentMethod)] ?? '';
+	}
+
+	private function buildPaymentMeans(string $paymentCode, string $iban): string
+	{
+		if ($paymentCode === '') {
+			return '';
+		}
+
+		$accountXml = '';
+		if (in_array($paymentCode, ['30', '58'], true)) {
+			$iban = strtoupper(preg_replace('/\s+/', '', $iban));
+			if ($iban === '') {
+				return '';
+			}
+			$iban = htmlspecialchars($iban, ENT_XML1);
+			$accountXml = "\n                <ram:PayeePartyCreditorFinancialAccount>\n                    <ram:IBANID>{$iban}</ram:IBANID>\n                </ram:PayeePartyCreditorFinancialAccount>";
+		}
+
+		$information = self::PAYMENT_MEANS[$paymentCode];
+
+		return <<<XML
+<ram:SpecifiedTradeSettlementPaymentMeans>
+                <ram:TypeCode>{$paymentCode}</ram:TypeCode>
+                <ram:Information>{$information}</ram:Information>{$accountXml}
+            </ram:SpecifiedTradeSettlementPaymentMeans>
+XML;
+	}
 }

--- a/src/css/mycss.less
+++ b/src/css/mycss.less
@@ -20,12 +20,21 @@
 }
 
 button.vat-category-help {
-  min-width: 30px;
-  min-height: 30px;
   margin: 0 0 0 4px;
-  padding: 2px;
-  border-radius: 50%;
+  padding: 0;
+  min-width: auto;
+  min-height: auto;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--color-main-text);
   vertical-align: middle;
+}
+
+button.vat-category-help:hover,
+button.vat-category-help:focus-visible {
+  background: transparent;
 }
 
 button.vat-category-help .material-symbols {

--- a/src/css/mycss.less
+++ b/src/css/mycss.less
@@ -41,6 +41,20 @@ button.vat-category-help .material-symbols {
   font-size: 20px;
 }
 
+.toastify.dialogs {
+  width: 30%;
+  max-width: 30%;
+  box-sizing: border-box;
+  white-space: normal;
+}
+
+@media (max-width: 768px) {
+  .toastify.dialogs {
+    width: calc(100% - 20px);
+    max-width: calc(100% - 20px);
+  }
+}
+
 table.dataTable.display tbody tr.odd > [class*="sorting_"] {
   background-color: var(--color-main-background);
 }

--- a/src/js/objects/facture.js
+++ b/src/js/objects/facture.js
@@ -5,6 +5,34 @@ import { setCsrfRequestHeader } from "../modules/csrf.js";
 
 export class Facture {
 
+  static PAYMENT_MEANS = [
+    ['10', 'Cash'],
+    ['20', 'Cheque'],
+    ['30', 'Credit transfer'],
+    ['48', 'Payment card'],
+    ['58', 'SEPA credit transfer'],
+  ];
+
+  static normalizePaymentMeans(value) {
+    const paymentMeans = String(value ?? '').trim();
+    if (Facture.PAYMENT_MEANS.some(([code]) => code === paymentMeans)) {
+      return paymentMeans;
+    }
+
+    const legacyPaymentMeans = {
+      cash: '10',
+      cheque: '20',
+      check: '20',
+      bank: '30',
+      'credit transfer': '30',
+      card: '48',
+      'payment card': '48',
+      'sepa credit transfer': '58',
+    };
+
+    return legacyPaymentMeans[paymentMeans.toLowerCase()] ?? '';
+  }
+
   /**
    * Facture object
    * @param myresp instantiate Facture object
@@ -16,7 +44,7 @@ export class Facture {
     this.num = ((myresp.num == null || myresp.num.length === 0) ? '-' : myresp.num);
     this.version = ((myresp.version == null || myresp.version.length === 0) ? '-' : myresp.version);
     this.date_paiement = ((myresp.date_paiement == null || myresp.date_paiement.length === 0) ? '-' : myresp.date_paiement);
-    this.type_paiement = ((myresp.type_paiement == null || myresp.type_paiement.length === 0) ? '-' : myresp.type_paiement);
+    this.type_paiement = Facture.normalizePaymentMeans(myresp.type_paiement);
     this.dnum = ((myresp.dnum == null || myresp.dnum.length === 0) ? '-' : myresp.dnum);
     this.nom = ((myresp.nom == null || myresp.nom.length === 0) ? '-' : myresp.nom);
     this.prenom = ((myresp.prenom == null || myresp.prenom.length === 0) ? '-' : myresp.prenom);
@@ -29,12 +57,15 @@ export class Facture {
    * Get datatable row for a devis
    */
   getDTRow() {
+    const paymentMeansOptions = `<option value=""${this.type_paiement === '' ? ' selected' : ''} disabled>${t('gestion', 'Select a means of payment')}</option>` + Facture.PAYMENT_MEANS.map(([code, label]) =>
+      `<option value="${code}"${this.type_paiement === code ? ' selected' : ''}>${t('gestion', label)}</option>`
+    ).join('');
     let myrow = [
       `<div>${this.user_id}</div>`,
       `<div class="editable factureNum" data-table="facture" data-column="num" data-id="${this.id}">${this.num}</div>`,
       `<div class="editable" data-table="facture" data-column="date" data-id="${this.id}">${this.date}</div>`,
       `<input style="margin:0;padding:0;" class="inputDate" type="date" value=${this.date_paiement} data-table="facture" data-column="date_paiement" data-id="${this.id}"/>`,
-      `<div class="editable" data-table="facture" data-column="type_paiement" data-id="${this.id}">${this.type_paiement}</div>`,
+      `<select class="editableSelect" data-table="facture" data-column="type_paiement" data-id="${this.id}" aria-label="${t('gestion', 'Means of payment')}">${paymentMeansOptions}</select>`,
       `<div class="loadSelect_listdevis" data-table="facture" data-column="id_devis" data-id="${this.id}" data-current="${this.id_devis}">${this.dnum} ${this.prenom} ${this.nom}</div>`,
       `<div class="editable" data-table="facture" data-column="version" data-id="${this.id}" style="display:inline">${this.version}</div>`,
       `<div class="editable" data-table="facture" data-column="status_paiement" data-id="${this.id}" style="display:inline">${this.status_paiement}</div>`,
@@ -88,6 +119,7 @@ export class Facture {
     };
     oReq.send(JSON.stringify({
       date_paiement: defaultPaymentDate,
+      type_paiement: '30',
     }));
   }
 

--- a/templates/content/produit.php
+++ b/templates/content/produit.php
@@ -16,7 +16,7 @@
                 <th>
 					<?php p($l->t('VAT category (France only)'));?>
 					<button type="button" id="vatCategoryHelp" class="vat-category-help" aria-label="<?php p($l->t('Explain VAT categories'));?>" title="<?php p($l->t('Explain VAT categories'));?>">
-						<span class="material-symbols" aria-hidden="true">help</span>
+						<span class="material-symbols" aria-hidden="true">warning_amber</span>
 					</button>
 				</th>
                 <th><?php p($l->t('Header'));?></th>

--- a/tests/Unit/Service/FacturXServiceTest.php
+++ b/tests/Unit/Service/FacturXServiceTest.php
@@ -34,6 +34,88 @@ class FacturXServiceTest extends TestCase {
 		$this->assertSame(1, substr_count($xml, '<ram:GuidelineSpecifiedDocumentContextParameter>'));
 	}
 
+	public function testDoesNotBuildAnEmptyHeaderTradeDelivery(): void {
+		$service = new FacturXService();
+		$invoice = (object)[
+			'date' => '2026-08-06',
+			'date_paiement' => '2026-09-06',
+			'num' => 'F-DELIVERY',
+		];
+		$products = [(object)[
+			'description' => 'Service',
+			'prix_unitaire' => 100,
+			'quantite' => 1,
+			'vat' => 20,
+		]];
+
+		$xml = $service->buildXml($invoice, (object)[], $products);
+
+		$this->assertStringNotContainsString('<ram:ApplicableHeaderTradeDelivery', $xml);
+	}
+
+	public function testDoesNotDeclareAnAccountingCurrencyWithoutItsVatTotal(): void {
+		$service = new FacturXService();
+		$invoice = (object)[
+			'date' => '2026-08-06',
+			'date_paiement' => '2026-09-06',
+			'num' => 'F-CURRENCY',
+		];
+		$products = [(object)[
+			'description' => 'Service',
+			'prix_unitaire' => 100,
+			'quantite' => 1,
+			'vat' => 20,
+		]];
+
+		$xml = $service->buildXml($invoice, (object)[], $products);
+
+		$this->assertStringContainsString('<ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>', $xml);
+		$this->assertStringNotContainsString('<ram:TaxCurrencyCode>', $xml);
+	}
+
+	public function testBuildsCreditTransferWithConfiguredIban(): void {
+		$service = new FacturXService();
+		$invoice = (object)[
+			'date' => '2026-08-06',
+			'date_paiement' => '2026-09-06',
+			'num' => 'F-TRANSFER',
+			'type_paiement' => '58',
+		];
+		$company = (object)['iban' => 'FR76 3000 6000 0112 3456 7890 189'];
+		$products = [(object)[
+			'description' => 'Service',
+			'prix_unitaire' => 100,
+			'quantite' => 1,
+			'vat' => 20,
+		]];
+
+		$xml = $service->buildXml($invoice, $company, $products);
+
+		$this->assertStringContainsString('<ram:TypeCode>58</ram:TypeCode>', $xml);
+		$this->assertStringContainsString('<ram:IBANID>FR7630006000011234567890189</ram:IBANID>', $xml);
+	}
+
+	public function testIgnoresUnsupportedFreeTextPaymentMeans(): void {
+		$service = new FacturXService();
+		$invoice = (object)[
+			'date' => '2026-08-06',
+			'date_paiement' => '2026-09-06',
+			'num' => 'F-FREE-TEXT',
+			'type_paiement' => 'Anything entered by a user',
+		];
+		$products = [(object)[
+			'description' => 'Service',
+			'prix_unitaire' => 100,
+			'quantite' => 1,
+			'vat' => 20,
+		]];
+
+		$xml = $service->buildXml($invoice, (object)[], $products);
+
+		$this->assertStringNotContainsString('<ram:SpecifiedTradeSettlementPaymentMeans>', $xml);
+		$this->assertStringNotContainsString('Anything entered by a user', $xml);
+	}
+
 	public function testBuildsQualifiedFrenchSellerAndBuyerIdentifiers(): void {
 		$service = new FacturXService();
 		$invoice = (object)[


### PR DESCRIPTION
### Motivation

- Encode payment means in the Factur‑X XML using standardized codes and include account details when applicable to comply with EN16931 expectations.
- Normalize legacy and free‑text payment descriptions into canonical payment codes to avoid invalid free‑text entries in the XML.
- Improve the invoice UI to let users pick a payment method from a predefined list instead of free text input.

### Description

- Added `PAYMENT_MEANS` mapping and implemented `getPaymentMeansCode()` and `buildPaymentMeans()` in `FacturXService` to emit a `<ram:SpecifiedTradeSettlementPaymentMeans>` element with `TypeCode`, human `Information`, and conditional `IBAN` for codes `30` and `58`.
- Replaced free‑text payment handling in `buildXml()` so the XML contains a structured payment means block and a `ram:Description` in payment terms when applicable, and removed the empty `<ram:ApplicableHeaderTradeDelivery/>` and unnecessary `TaxCurrencyCode` emission.
- Updated the frontend `src/js/objects/facture.js` to provide a `PAYMENT_MEANS` list, a `normalizePaymentMeans()` helper that maps legacy/free‑text values to codes, renders a `<select>` in the datatable for `type_paiement`, and sets the default payment method to `30` for new invoices.
- Added unit tests in `tests/Unit/Service/FacturXServiceTest.php` covering absence of empty `<ram:ApplicableHeaderTradeDelivery>`, omission of `TaxCurrencyCode` when not appropriate, correct IBAN formatting for credit transfer (`58`), and ignoring unsupported free‑text payment means.

### Testing

- Ran the updated unit test suite with `phpunit tests/Unit/Service/FacturXServiceTest.php` and the new tests passed. 
- Executed the broader unit tests in the service layer and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a747968a46483328b24d87c8853ba2a)