### PR TITLE
Simplify VAT category help icon

### DIFF
--- a/src/css/mycss.less
+++ b/src/css/mycss.less
@@ -20,16 +20,22 @@
 }
 
 button.vat-category-help {
-  margin: 0 0 0 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin: 0 0 0 3px;
   padding: 0;
-  min-width: auto;
-  min-height: auto;
+  min-width: 16px;
+  min-height: 16px;
   border: 0;
   border-radius: 0;
   background: transparent;
   box-shadow: none;
   color: var(--color-main-text);
   vertical-align: middle;
+  line-height: 1;
 }
 
 button.vat-category-help:hover,
@@ -37,8 +43,10 @@ button.vat-category-help:focus-visible {
   background: transparent;
 }
 
-button.vat-category-help .material-symbols {
-  font-size: 20px;
+button.vat-category-help .vat-category-help-icon {
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
 }
 
 .toastify.dialogs {

--- a/templates/content/produit.php
+++ b/templates/content/produit.php
@@ -16,7 +16,7 @@
                 <th>
 					<?php p($l->t('VAT category (France only)'));?>
 					<button type="button" id="vatCategoryHelp" class="vat-category-help" aria-label="<?php p($l->t('Explain VAT categories'));?>" title="<?php p($l->t('Explain VAT categories'));?>">
-						<span class="material-symbols" aria-hidden="true">warning_amber</span>
+						<span class="vat-category-help-icon" aria-hidden="true">!</span>
 					</button>
 				</th>
                 <th><?php p($l->t('Header'));?></th>


### PR DESCRIPTION
### Motivation
- The VAT category help control was visually prominent and used a large warning glyph, the goal is to make it a small, simple inline icon next to the column label. 
- The change aims for a compact, accessible indicator that does not draw excessive attention while keeping the help button available. 

### Description
- Replace the oversized material icon in `templates/content/produit.php` with a plain text exclamation element (`<span class="vat-category-help-icon">!</span>`) kept inside the existing help button. 
- Constrain and restyle the control in `src/css/mycss.less` by making `button.vat-category-help` an `inline-flex` 16×16px square, centering its content and removing default button visuals. 
- Style the new `.vat-category-help-icon` at `14px` and bold to preserve legibility inside the compact control. 

### Testing
- Ran `npm run build` and the webpack build completed without error. 
- Checked PHP syntax with `php -l templates/content/produit.php` and it reported no syntax errors. 
- Ran `npm run verify:template-scripts` and it confirmed that all JavaScript files referenced by templates exist. 
- Ran `git diff --check` and no whitespace or diff-check issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a748637b76883328a927b5006b2b58c)