### PR TITLE
Align VAT category header

### DIFF
--- a/src/css/mycss.less
+++ b/src/css/mycss.less
@@ -19,34 +19,15 @@
   min-width: 12rem;
 }
 
-button.vat-category-help {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  margin: 0 0 0 3px;
-  padding: 0;
-  min-width: 16px;
-  min-height: 16px;
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-  box-shadow: none;
+.vat-category-help {
+  display: inline-block;
+  margin-left: 3px;
   color: var(--color-main-text);
   vertical-align: middle;
   line-height: 1;
-}
-
-button.vat-category-help:hover,
-button.vat-category-help:focus-visible {
-  background: transparent;
-}
-
-button.vat-category-help .vat-category-help-icon {
   font-size: 14px;
   font-weight: 700;
-  line-height: 1;
+  cursor: pointer;
 }
 
 .toastify.dialogs {

--- a/src/js/produit.js
+++ b/src/js/produit.js
@@ -14,7 +14,16 @@ window.addEventListener("DOMContentLoaded", function () {
 
     Produit.loadProduitDT(new DataTable(".tabledt",optionDatatable));
 
-    document.getElementById('vatCategoryHelp')?.addEventListener('click', () => {
+    const vatCategoryHelp = document.getElementById('vatCategoryHelp');
+    const showVatCategoryHelp = () => {
         showMessage(t('gestion', 'France only: this category describes why VAT applies or does not apply in the Factur-X electronic invoice. Choose S for VAT at 5.5%, 10% or 20%; E for the French small-business exemption (article 293 B); Z only for a legally zero-rated taxable supply; O for an operation outside the scope of VAT; AE for reverse charge; G for export outside the EU; or K for an intra-Community supply.'));
+    };
+
+    vatCategoryHelp?.addEventListener('click', showVatCategoryHelp);
+    vatCategoryHelp?.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            showVatCategoryHelp();
+        }
     });
 });

--- a/templates/content/produit.php
+++ b/templates/content/produit.php
@@ -13,12 +13,10 @@
                 <th><?php p($l->t('Designation'));?></th>
                 <th><?php p($l->t('Unit price without VAT'));?></th>
                 <th><?php p($l->t('VAT percentage'));?></th>
-                <th>
-					<?php p($l->t('VAT category (France only)'));?>
-					<button type="button" id="vatCategoryHelp" class="vat-category-help" aria-label="<?php p($l->t('Explain VAT categories'));?>" title="<?php p($l->t('Explain VAT categories'));?>">
-						<span class="vat-category-help-icon" aria-hidden="true">!</span>
-					</button>
-				</th>
+	            <th>
+	                <span><?php p($l->t('VAT category (France only)'));?></span>
+	                <span id="vatCategoryHelp" class="vat-category-help" role="button" tabindex="0" aria-label="<?php p($l->t('Explain VAT categories'));?>" title="<?php p($l->t('Explain VAT categories'));?>">!</span>
+	            </th>
                 <th><?php p($l->t('Header'));?></th>
                 <th><?php p($l->t('Actions'));?></th>
             </tr>


### PR DESCRIPTION
### Motivation
- Fix misalignment of the "VAT category" column header by simplifying the markup so the label and help marker sit on the same line. 
- Keep the VAT help reachable for keyboard and assistive technologies while removing nested button complexity.

### Description
- Replace the nested help `<button>` with two inline spans (label + help marker) and add `role="button"` and `tabindex="0"` to preserve discoverability and keyboard focus in `templates/content/produit.php`.
- Simplify styling by converting the previous `button.vat-category-help` rules to a simpler `.vat-category-help` inline span style and remove unnecessary sizing/box rules in `src/css/mycss.less`.
- Retain the help behaviour and add keyboard handling by moving the handler to `src/js/produit.js`, wiring `click` and `keydown` (Enter/Space) to show the explanatory message.
- Changes are on branch `codex/issue-577` and this PR is intended as a draft for review (do not merge automatically).

### Testing
- `npm run build` completed successfully (Webpack compiled with existing bundle-size warnings). 
- `npm run verify:template-scripts` passed and confirmed referenced JS files exist. 
- `php -l templates/content/produit.php` reported no syntax errors. 
- `git diff --check` returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a748dd7c0fc8332b7d405f855aed0da)