### PR TITLE
Validate Factur-X XSD and French business rules

### DIFF
--- a/.github/workflows/facturx-validation.yml
+++ b/.github/workflows/facturx-validation.yml
@@ -1,0 +1,37 @@
+name: Factur-X validation
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Validate Factur-X XSD and Schematron rules
+        run: make validate-facturx

--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,10 @@ sign-appstore:
 test:
 	vendor/bin/phpunit --colors=always --testdox
 
+.PHONY: validate-facturx
+validate-facturx:
+	./scripts/validate-facturx.sh "$(FACTURX_SOURCE)"
+
 .PHONY: testPanther
 testPanther:
 	killall geckodriver; php tests/Unit/Panther/IhmTest.php

--- a/composer.lock
+++ b/composer.lock
@@ -711,29 +711,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.4"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^14",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpunit/phpunit": "^10.5.58"
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -760,7 +761,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -776,7 +777,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T06:47:08+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/lib/Service/FacturXService.php
+++ b/lib/Service/FacturXService.php
@@ -10,6 +10,11 @@ class FacturXService
 	public const PROFILE_ID = 'urn:cen.eu:en16931:2017';
 	private const VAT_EXEMPTION_REASON = 'TVA non applicable, art. 293 B du CGI';
 	private const VAT_CATEGORIES = ['S', 'E', 'Z', 'O', 'AE', 'G', 'K'];
+	private const FRENCH_INVOICE_NOTES = [
+		'PMT' => 'Indemnité forfaitaire de 40 euros pour frais de recouvrement due en cas de retard de paiement.',
+		'PMD' => 'Pénalités de retard exigibles au taux annuel de trois fois le taux d’intérêt légal en vigueur.',
+		'AAB' => 'Aucun escompte accordé pour paiement anticipé.',
+	];
 	private const PAYMENT_MEANS = [
 		'10' => 'Cash',
 		'20' => 'Cheque',
@@ -295,6 +300,7 @@ XML;
         $sellerZip = htmlspecialchars($company->zip_code ?? '', ENT_XML1);
 
         $sellerCountry = htmlspecialchars($company->pays ?? 'FR', ENT_XML1);
+		$sellerEndpointXml = $this->buildElectronicAddress((string)($company->mail ?? ''));
 
         $buyerName = htmlspecialchars(
             trim(($invoice->prenom ?? '') . ' ' . ($invoice->nom ?? '')),
@@ -305,6 +311,7 @@ XML;
         $buyerZip = htmlspecialchars($customer->zip_code ?? '', ENT_XML1);
         $buyerCity = htmlspecialchars($customer->city_name ?? '', ENT_XML1);
         $buyerCountry = htmlspecialchars($customer->country_code ?? 'FR', ENT_XML1);
+		$buyerEndpointXml = $this->buildElectronicAddress((string)($customer->mail ?? ''));
 		$buyerCompanyId = trim($customer->company_identification ?? '');
 		$buyerVatId = htmlspecialchars(trim($customer->vat_number ?? ''), ENT_XML1);
 		$buyerSiret = ElectronicInvoiceIdentifiers::siretFrom($buyerCompanyId);
@@ -332,6 +339,7 @@ XML;
         $invoiceDateFormatted = $invoiceDate->format('Ymd');
         $dueDateFormatted = $dueDate->format('Ymd');
 		$profileId = self::PROFILE_ID;
+		$invoiceNotesXml = $this->buildFrenchInvoiceNotes();
 
         return <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -354,10 +362,10 @@ XML;
         <ram:TypeCode>380</ram:TypeCode>
 
         <ram:IssueDateTime>
-            <udt:DateTimeString format="102">
-                {$invoiceDateFormatted}
-            </udt:DateTimeString>
+            <udt:DateTimeString format="102">{$invoiceDateFormatted}</udt:DateTimeString>
         </ram:IssueDateTime>
+
+		{$invoiceNotesXml}
     </rsm:ExchangedDocument>
 
     <rsm:SupplyChainTradeTransaction>
@@ -380,6 +388,8 @@ XML;
                     <ram:CityName>{$sellerCity}</ram:CityName>
                     <ram:CountryID>{$sellerCountry}</ram:CountryID>
                 </ram:PostalTradeAddress>
+
+				{$sellerEndpointXml}
 
 				{$sellerVatIdXml}
 
@@ -405,11 +415,21 @@ XML;
 
     </ram:PostalTradeAddress>
 
+    {$buyerEndpointXml}
+
     {$buyerVatIdXml}
 
 </ram:BuyerTradeParty>
 
         </ram:ApplicableHeaderTradeAgreement>
+
+        <ram:ApplicableHeaderTradeDelivery>
+            <ram:ActualDeliverySupplyChainEvent>
+                <ram:OccurrenceDateTime>
+                    <udt:DateTimeString format="102">{$invoiceDateFormatted}</udt:DateTimeString>
+                </ram:OccurrenceDateTime>
+            </ram:ActualDeliverySupplyChainEvent>
+        </ram:ApplicableHeaderTradeDelivery>
 
         <ram:ApplicableHeaderTradeSettlement>
 
@@ -425,9 +445,7 @@ XML;
                 {$paymentDescriptionXml}
 
                 <ram:DueDateDateTime>
-                    <udt:DateTimeString format="102">
-                        {$dueDateFormatted}
-                    </udt:DateTimeString>
+                    <udt:DateTimeString format="102">{$dueDateFormatted}</udt:DateTimeString>
                 </ram:DueDateDateTime>
 
             </ram:SpecifiedTradePaymentTerms>
@@ -449,6 +467,34 @@ XML;
 </rsm:CrossIndustryInvoice>
 XML;
     }
+
+	private function buildElectronicAddress(string $email): string
+	{
+		$email = trim($email);
+		if ($email === '') {
+			return '';
+		}
+
+		$email = htmlspecialchars($email, ENT_XML1);
+
+		return "<ram:URIUniversalCommunication><ram:URIID schemeID=\"EM\">{$email}</ram:URIID></ram:URIUniversalCommunication>";
+	}
+
+	private function buildFrenchInvoiceNotes(): string
+	{
+		$notes = [];
+		foreach (self::FRENCH_INVOICE_NOTES as $subjectCode => $content) {
+			$content = htmlspecialchars($content, ENT_XML1);
+			$notes[] = <<<XML
+<ram:IncludedNote>
+            <ram:Content>{$content}</ram:Content>
+            <ram:SubjectCode>{$subjectCode}</ram:SubjectCode>
+        </ram:IncludedNote>
+XML;
+		}
+
+		return implode("\n\n        ", $notes);
+	}
 
 	private function getPaymentMeansCode(string $paymentMethod): string
 	{

--- a/scripts/generate-facturx-validation-fixture.php
+++ b/scripts/generate-facturx-validation-fixture.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+$projectDirectory = dirname(__DIR__);
+
+require $projectDirectory . '/vendor/autoload.php';
+require $projectDirectory . '/lib/Service/ElectronicInvoiceIdentifiers.php';
+require $projectDirectory . '/lib/Service/FacturXService.php';
+
+use OCA\Gestion\Service\FacturXService;
+
+if ($argc !== 2) {
+	fwrite(STDERR, "Usage: php scripts/generate-facturx-validation-fixture.php <output.xml>\n");
+	exit(2);
+}
+
+$invoice = (object)[
+	'date' => '2026-08-06',
+	'date_paiement' => '2026-09-06',
+	'num' => 'F-2026-0001',
+	'type_paiement' => '58',
+	'prenom' => 'Alice',
+	'nom' => 'Martin',
+];
+$company = (object)[
+	'entreprise' => 'Gestion SAS',
+	'adresse' => '1 rue de Paris',
+	'zip_code' => '75001',
+	'city_name' => 'Paris',
+	'pays' => 'FR',
+	'mail' => 'billing@gestion.example',
+	'vat_number' => 'FR40303265045',
+	'iban' => 'FR7630006000011234567890189',
+	'legal_one' => 'SIRET: 30326504500018',
+	'legal_two' => 'SIREN: 303265045',
+];
+$customer = (object)[
+	'adresse' => '10 avenue de Lyon',
+	'zip_code' => '69001',
+	'city_name' => 'Lyon',
+	'country_code' => 'FR',
+	'mail' => 'accounting@customer.example',
+	'company_identification' => '552100554',
+	'vat_number' => 'FR82552100554',
+];
+$products = [
+	(object)[
+		'description' => 'Consulting service',
+		'prix_unitaire' => 100,
+		'quantite' => 2,
+		'vat' => 20,
+		'vat_category' => 'S',
+	],
+];
+
+$xml = (new FacturXService())->buildXml($invoice, $company, $products, $customer);
+if (file_put_contents($argv[1], $xml) === false) {
+	fwrite(STDERR, "Unable to write Factur-X validation fixture to {$argv[1]}\n");
+	exit(1);
+}

--- a/scripts/validate-facturx.sh
+++ b/scripts/validate-facturx.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+project_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mustang_version="2.25.0"
+mustang_sha256="d68b9fd6a9948a0964b7c93ed06b7e903a6dbafcd0df581e992e3178bf016701"
+mustang_url="https://github.com/ZUGFeRD/mustangproject/releases/download/core-${mustang_version}/Mustang-CLI-${mustang_version}.jar"
+tools_directory="${project_directory}/build/tools"
+reports_directory="${project_directory}/build/reports/facturx"
+mustang_jar="${tools_directory}/Mustang-CLI-${mustang_version}.jar"
+generated_source="${reports_directory}/gestion-en16931.xml"
+source_file="${1:-${generated_source}}"
+report_file="${reports_directory}/validation-report.xml"
+log_file="${reports_directory}/validation.log"
+
+for command_name in curl java php sha256sum; do
+	if ! command -v "${command_name}" >/dev/null 2>&1; then
+		echo "Missing required command: ${command_name}" >&2
+		exit 2
+	fi
+done
+
+mkdir -p "${tools_directory}" "${reports_directory}"
+
+if [ ! -f "${mustang_jar}" ]; then
+	temporary_jar="${mustang_jar}.download"
+	curl --fail --location --retry 3 --output "${temporary_jar}" "${mustang_url}"
+	mv "${temporary_jar}" "${mustang_jar}"
+fi
+
+echo "${mustang_sha256}  ${mustang_jar}" | sha256sum --check --status || {
+	echo "Mustang CLI checksum verification failed: ${mustang_jar}" >&2
+	exit 1
+}
+
+if [ "${source_file}" = "${generated_source}" ]; then
+	php "${project_directory}/scripts/generate-facturx-validation-fixture.php" "${generated_source}"
+elif [ ! -f "${source_file}" ]; then
+	echo "Factur-X source not found: ${source_file}" >&2
+	exit 2
+fi
+
+set +e
+java -Xmx1G -Dfile.encoding=UTF-8 -jar "${mustang_jar}" \
+	--action validate \
+	--source "${source_file}" \
+	--no-notices \
+	>"${report_file}" 2>"${log_file}"
+validator_status=$?
+set -e
+
+if [ "${validator_status}" -ne 0 ] \
+	|| grep -Eq '<failed>[1-9][0-9]*</failed>|<(error|warning)([ >])|<summary status="invalid"' "${report_file}"; then
+	echo "Factur-X validation failed. Report: ${report_file}" >&2
+	grep -E '<(error|warning)([ >])' "${report_file}" >&2 || true
+	exit 1
+fi
+
+echo "Factur-X XSD and Schematron validation passed: ${source_file}"
+echo "Validation report: ${report_file}"

--- a/tests/Unit/Service/FacturXServiceTest.php
+++ b/tests/Unit/Service/FacturXServiceTest.php
@@ -34,7 +34,7 @@ class FacturXServiceTest extends TestCase {
 		$this->assertSame(1, substr_count($xml, '<ram:GuidelineSpecifiedDocumentContextParameter>'));
 	}
 
-	public function testDoesNotBuildAnEmptyHeaderTradeDelivery(): void {
+	public function testBuildsHeaderTradeDeliveryBeforeSettlement(): void {
 		$service = new FacturXService();
 		$invoice = (object)[
 			'date' => '2026-08-06',
@@ -50,7 +50,72 @@ class FacturXServiceTest extends TestCase {
 
 		$xml = $service->buildXml($invoice, (object)[], $products);
 
-		$this->assertStringNotContainsString('<ram:ApplicableHeaderTradeDelivery', $xml);
+		$this->assertStringContainsString(
+			'<udt:DateTimeString format="102">20260806</udt:DateTimeString>',
+			$xml
+		);
+		$this->assertLessThan(
+			strpos($xml, '<ram:ApplicableHeaderTradeSettlement>'),
+			strpos($xml, '<ram:ApplicableHeaderTradeDelivery>')
+		);
+		$this->assertStringContainsString(
+			'<udt:DateTimeString format="102">20260906</udt:DateTimeString>',
+			$xml
+		);
+	}
+
+	public function testBuildsMandatoryFrenchInvoiceNotes(): void {
+		$service = new FacturXService();
+		$invoice = (object)[
+			'date' => '2026-08-06',
+			'date_paiement' => '2026-09-06',
+			'num' => 'F-NOTES',
+		];
+		$products = [(object)[
+			'description' => 'Service',
+			'prix_unitaire' => 100,
+			'quantite' => 1,
+			'vat' => 20,
+		]];
+
+		$xml = $service->buildXml($invoice, (object)[], $products);
+
+		foreach (['PMT', 'PMD', 'AAB'] as $subjectCode) {
+			$this->assertStringContainsString(
+				'<ram:SubjectCode>' . $subjectCode . '</ram:SubjectCode>',
+				$xml
+			);
+		}
+		$this->assertSame(3, substr_count($xml, '<ram:IncludedNote>'));
+	}
+
+	public function testBuildsSellerAndBuyerElectronicAddresses(): void {
+		$service = new FacturXService();
+		$invoice = (object)[
+			'date' => '2026-08-06',
+			'date_paiement' => '2026-09-06',
+			'num' => 'F-ENDPOINTS',
+		];
+		$company = (object)['mail' => 'seller&billing@example.com'];
+		$customer = (object)['mail' => 'buyer@example.com'];
+		$products = [(object)[
+			'description' => 'Service',
+			'prix_unitaire' => 100,
+			'quantite' => 1,
+			'vat' => 20,
+		]];
+
+		$xml = $service->buildXml($invoice, $company, $products, $customer);
+
+		$this->assertStringContainsString(
+			'<ram:URIID schemeID="EM">seller&amp;billing@example.com</ram:URIID>',
+			$xml
+		);
+		$this->assertStringContainsString(
+			'<ram:URIID schemeID="EM">buyer@example.com</ram:URIID>',
+			$xml
+		);
+		$this->assertSame(2, substr_count($xml, '<ram:URIUniversalCommunication>'));
 	}
 
 	public function testDoesNotDeclareAnAccountingCurrencyWithoutItsVatTotal(): void {


### PR DESCRIPTION
## What changed

- correct the Factur-X EN16931 document order by emitting Delivery before Settlement
- normalize issue and due dates without whitespace
- add the mandatory French PMT, PMD and AAB invoice notes
- add seller and buyer electronic addresses (BT-34 and BT-49)
- add a reproducible Mustang CLI validation command through `make validate-facturx`
- add a pull-request workflow that checks XSD, EN16931 Schematron and French Flux 2 rules
- restore PHP 8.3 compatibility for the PHPUnit dependency lock

## Why

The existing generator could produce XML that failed the official XSD and French business rules. Mustang also reports some failed Schematron assertions as warnings while returning a successful process status, so the validation script explicitly rejects non-zero failed-rule counts, warnings and errors.

## Impact

Generated French Factur-X EN16931 invoices now include the mandatory structured information, and future regressions are blocked automatically in CI. The Mustang JAR is downloaded into the ignored build directory and verified against a pinned SHA-256 checksum.

## Validation

- `11` PHPUnit tests, `52` assertions
- Factur-X XSD validation: passed
- Schematron validation: `53` rules fired, `0` failed
- negative control: removing BT-34 makes the command fail with `BR-FR-13_BT-34`