### PR TITLE
Fix Factur-X buyer company name

### DIFF
--- a/lib/Service/FacturXService.php
+++ b/lib/Service/FacturXService.php
@@ -306,10 +306,16 @@ XML;
         $sellerCountry = htmlspecialchars($company->pays ?? 'FR', ENT_XML1);
 		$sellerEndpointXml = $this->buildElectronicAddress((string)($company->mail ?? ''));
 
-        $buyerName = htmlspecialchars(
-            trim(($invoice->prenom ?? '') . ' ' . ($invoice->nom ?? '')),
-            ENT_XML1
-        );
+		$buyerCompanyName = trim((string)($customer->entreprise ?? $invoice->entreprise ?? ''));
+		$buyerPersonName = trim(
+			(string)($customer->prenom ?? $invoice->prenom ?? '')
+			. ' '
+			. (string)($customer->nom ?? $invoice->nom ?? '')
+		);
+		$buyerName = htmlspecialchars(
+			$buyerCompanyName !== '' ? $buyerCompanyName : $buyerPersonName,
+			ENT_XML1
+		);
 
         $buyerAddress = htmlspecialchars($customer->adresse ?? '', ENT_XML1);
         $buyerZip = htmlspecialchars($customer->zip_code ?? '', ENT_XML1);

--- a/tests/Unit/Service/FacturXServiceTest.php
+++ b/tests/Unit/Service/FacturXServiceTest.php
@@ -118,6 +118,59 @@ class FacturXServiceTest extends TestCase {
 		$this->assertSame(2, substr_count($xml, '<ram:URIUniversalCommunication>'));
 	}
 
+	public function testUsesCompanyNameForBuyerWhenAvailable(): void {
+		$service = new FacturXService();
+		$invoice = (object)[
+			'date' => '2026-08-06',
+			'date_paiement' => '2026-09-06',
+			'num' => 'F-BUYER-COMPANY',
+			'entreprise' => 'Customer & Partners',
+			'prenom' => 'Ludovic',
+			'nom' => 'Lastennet',
+		];
+		$products = [(object)[
+			'description' => 'Service',
+			'prix_unitaire' => 100,
+			'quantite' => 1,
+			'vat' => 20,
+		]];
+
+		$xml = $service->buildXml($invoice, (object)[], $products);
+		$buyerXml = $this->extractBuyerTradeParty($xml);
+
+		$this->assertStringContainsString(
+			'<ram:Name>Customer &amp; Partners</ram:Name>',
+			$buyerXml
+		);
+		$this->assertStringNotContainsString('Ludovic Lastennet', $buyerXml);
+	}
+
+	public function testUsesPersonNameForBuyerWithoutCompanyName(): void {
+		$service = new FacturXService();
+		$invoice = (object)[
+			'date' => '2026-08-06',
+			'date_paiement' => '2026-09-06',
+			'num' => 'F-BUYER-PERSON',
+			'entreprise' => '  ',
+			'prenom' => 'Ludovic',
+			'nom' => 'Lastennet',
+		];
+		$products = [(object)[
+			'description' => 'Service',
+			'prix_unitaire' => 100,
+			'quantite' => 1,
+			'vat' => 20,
+		]];
+
+		$xml = $service->buildXml($invoice, (object)[], $products);
+		$buyerXml = $this->extractBuyerTradeParty($xml);
+
+		$this->assertStringContainsString(
+			'<ram:Name>Ludovic Lastennet</ram:Name>',
+			$buyerXml
+		);
+	}
+
 	public function testDoesNotDeclareAnAccountingCurrencyWithoutItsVatTotal(): void {
 		$service = new FacturXService();
 		$invoice = (object)[
@@ -317,5 +370,15 @@ class FacturXServiceTest extends TestCase {
 		$this->assertSame(2, substr_count($xml, '<ram:CategoryCode>S</ram:CategoryCode>'));
 		$this->assertStringNotContainsString('<ram:CategoryCode>E</ram:CategoryCode>', $xml);
 		$this->assertStringContainsString('<ram:RateApplicablePercent>5.5</ram:RateApplicablePercent>', $xml);
+	}
+
+	private function extractBuyerTradeParty(string $xml): string {
+		$start = strpos($xml, '<ram:BuyerTradeParty>');
+		$end = strpos($xml, '</ram:BuyerTradeParty>');
+
+		$this->assertNotFalse($start);
+		$this->assertNotFalse($end);
+
+		return substr($xml, $start, $end - $start);
 	}
 }


### PR DESCRIPTION
## What changed

- use the customer's company name for `BuyerTradeParty/Name` when it is available
- fall back to the customer's first and last name for individual customers
- add focused tests for both company and individual buyer names, including XML escaping

## Why

Factur-X XML always used the customer's personal name, even when the customer record contained a company name. External invoice viewers therefore displayed the contact person instead of the buyer company.

## Impact

Business invoices now expose the expected company name in Factur-X viewers. Individual customer invoices keep their existing personal-name behavior.

## Validation

- PHPUnit: 14 tests, 62 assertions
- Factur-X XSD and Schematron validation passed
- PHP syntax checks passed
