### PR TITLE
Import Nextcloud Contacts into Customers (UI + backend mapping)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -18,6 +18,8 @@ return [
         ['name' => 'crud#update', 'url' => '/update', 'verb' => 'POST'],
         ['name' => 'configuration#updateConfiguration', 'url' => '/updateConfiguration', 'verb' => 'POST'],
         ['name' => 'client#insertClient', 'url' => '/client/insert', 'verb' => 'POST'],
+        ['name' => 'client#getContacts', 'url' => '/contacts', 'verb' => 'GET'],
+        ['name' => 'client#insertClientFromContact', 'url' => '/client/insert-from-contact', 'verb' => 'POST'],
 
         ['name' => 'devis#getDevis', 'url' => '/getDevis', 'verb' => 'PROPFIND'],
         ['name' => 'devis#devisshow', 'url' => '/devis/{numdevis}/show', 'verb' => 'GET'],

--- a/lib/Controller/ClientController.php
+++ b/lib/Controller/ClientController.php
@@ -48,10 +48,29 @@ class ClientController extends Controller {
 
 	/**
 	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 * @UseSession
+	 */
+	#[UseSession]
+	public function getContacts($search = '') {
+		return $this->dataService->getContacts($search);
+	}
+
+	/**
+	 * @NoAdminRequired
 	 * @UseSession
 	 */
 	#[UseSession]
 	public function insertClient() {
 		return $this->dataService->insertClient();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @UseSession
+	 */
+	#[UseSession]
+	public function insertClientFromContact() {
+		return $this->dataService->insertClientFromContact($this->request->getParams());
 	}
 }

--- a/lib/Db/Bdd.php
+++ b/lib/Db/Bdd.php
@@ -104,21 +104,42 @@ class Bdd {
     }
 
     public function insertClient($idNextcloud){
+        return $this->insertClientFromData($idNextcloud, array(
+            'Last name' => $this->l->t('Last name'),
+            'First name' => $this->l->t('First name'),
+            'Legal information' => $this->l->t('Limited company'),
+            'Company' => $this->l->t('Company'),
+            'Phone number' => $this->l->t('Phone number'),
+            'Email' => $this->l->t('Email'),
+            'Address' => $this->l->t('Address'),
+            'Zip code' => $this->l->t('Zip code'),
+            'City name' => $this->l->t('City name'),
+            'Country code' => 'FR',
+        ));
+    }
+
+    public function insertClientFromData($idNextcloud, array $client){
         $sql = "INSERT INTO `".$this->tableprefix."client` (`id_configuration`,`nom`,`prenom`,`legal_one`,`entreprise`,`telephone`,`mail`,`adresse`,`zip_code`,`city_name`,`country_code`) VALUES (?,?,?,?,?,?,?,?,?,?,?)";
-        $this->execSQLNoData($sql,array($idNextcloud,
-                                            $this->l->t('Last name'),
-                                            $this->l->t('First name'),
-                                            $this->l->t('Limited company'),
-                                            $this->l->t('Company'),
-                                            $this->l->t('Phone number'),
-                                            $this->l->t('Email'),
-                                            $this->l->t('Address'),
-                                            $this->l->t('zip_code'),
-                                            $this->l->t('city_name'),
-                                            'FR'
-                                        )
-                                    );
+        $this->execSQLNoData($sql,array(
+            $idNextcloud,
+            $this->sanitizeClientValue($client['Last name'] ?? ''),
+            $this->sanitizeClientValue($client['First name'] ?? ''),
+            $this->sanitizeClientValue($client['Legal information'] ?? ''),
+            $this->sanitizeClientValue($client['Company'] ?? ''),
+            $this->sanitizeClientValue($client['Phone number'] ?? ''),
+            $this->sanitizeClientValue($client['Email'] ?? ''),
+            $this->sanitizeClientValue($client['Address'] ?? ''),
+            $this->normalizeColumnData('zip_code', $this->sanitizeClientValue($client['Zip code'] ?? '')),
+            $this->sanitizeClientValue($client['City name'] ?? ''),
+            $this->normalizeColumnData('country_code', $this->sanitizeClientValue($client['Country code'] ?? '')),
+        ));
         return true;
+    }
+
+    private function sanitizeClientValue($data){
+        $safeData = strip_tags((string)$data, '<br>');
+        $safeData = html_entity_decode($safeData, ENT_QUOTES, 'UTF-8');
+        return rtrim($safeData);
     }
 
     public function insertDevis($idNextcloud){

--- a/lib/Service/DataService.php
+++ b/lib/Service/DataService.php
@@ -3,6 +3,7 @@ namespace OCA\Gestion\Service;
 
 use OCA\Gestion\Db\Bdd;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\Contacts\IManager as ContactsManager;
 use OCP\IConfig;
 use OCP\ISession;
 
@@ -10,11 +11,13 @@ class DataService {
 	private Bdd $myDb;
 	private IConfig $config;
 	private ISession $session;
+	private ContactsManager $contactsManager;
 
-	public function __construct(Bdd $myDb, IConfig $config, ISession $session) {
+	public function __construct(Bdd $myDb, IConfig $config, ISession $session, ContactsManager $contactsManager) {
 		$this->myDb = $myDb;
 		$this->config = $config;
 		$this->session = $session;
+		$this->contactsManager = $contactsManager;
 	}
 
 	private function currentCompany() {
@@ -63,6 +66,86 @@ class DataService {
 
 	public function insertClient() {
 		return $this->myDb->insertClient($this->currentCompany());
+	}
+
+	public function getContacts(string $search = ''): DataResponse {
+		if (!$this->contactsManager->isEnabled()) {
+			return new DataResponse([], 200, ['Content-Type' => 'application/json']);
+		}
+
+		$contacts = $this->contactsManager->search($search, ['FN', 'N', 'ORG', 'EMAIL', 'TEL', 'ADR'], ['limit' => 100]);
+		$mappedContacts = array_map([$this, 'mapContactToClient'], $contacts);
+		$mappedContacts = array_values(array_filter($mappedContacts, static function ($contact) {
+			return $contact['label'] !== '';
+		}));
+
+		return new DataResponse($mappedContacts, 200, ['Content-Type' => 'application/json']);
+	}
+
+	public function insertClientFromContact(array $client): DataResponse {
+		$this->myDb->insertClientFromData($this->currentCompany(), $client);
+		return new DataResponse('', 200, ['Content-Type' => 'application/json']);
+	}
+
+	private function mapContactToClient(array $contact): array {
+		$name = $this->firstValue($contact['N'] ?? '');
+		$fullName = $this->firstString($contact['FN'] ?? '');
+		$nameParts = is_array($name) ? array_values($name) : explode(';', $name);
+		$lastName = trim((string)($nameParts[0] ?? ''));
+		$firstName = trim((string)($nameParts[1] ?? ''));
+
+		if ($firstName === '' && $lastName === '' && $fullName !== '') {
+			$parts = preg_split('/\s+/', $fullName, 2);
+			$firstName = $parts[0] ?? '';
+			$lastName = $parts[1] ?? '';
+		}
+
+		$address = $this->firstValue($contact['ADR'] ?? '');
+		$addressParts = is_array($address) ? array_values($address) : explode(';', $address);
+		$street = trim((string)($addressParts[2] ?? ''));
+		$city = trim((string)($addressParts[3] ?? ''));
+		$zipCode = trim((string)($addressParts[5] ?? ''));
+		$country = strtoupper(trim((string)($addressParts[6] ?? '')));
+		$countryCode = preg_match('/^[A-Z]{2}$/', $country) ? $country : '';
+
+		$company = $this->firstString($contact['ORG'] ?? '');
+		$label = trim($company ?: $fullName ?: trim($firstName . ' ' . $lastName));
+
+		return [
+			'label' => $label,
+			'Company' => $company,
+			'First name' => $firstName,
+			'Last name' => $lastName,
+			'Legal information' => '',
+			'Phone number' => $this->firstString($contact['TEL'] ?? ''),
+			'Email' => $this->firstString($contact['EMAIL'] ?? ''),
+			'Address' => $street,
+			'Zip code' => $zipCode,
+			'City name' => $city,
+			'Country code' => $countryCode,
+		];
+	}
+
+	private function firstValue($value) {
+		if (is_array($value)) {
+			$value = reset($value);
+		}
+
+		if (is_array($value) && array_key_exists('value', $value)) {
+			$value = $value['value'];
+		}
+
+		return $value;
+	}
+
+	private function firstString($value): string {
+		$value = $this->firstValue($value);
+
+		if (is_array($value)) {
+			$value = reset($value);
+		}
+
+		return trim((string)$value);
 	}
 
 	public function insertDevis() {

--- a/src/js/listener/handlers/contact_handlers.js
+++ b/src/js/listener/handlers/contact_handlers.js
@@ -1,0 +1,10 @@
+import DataTable from 'datatables.net';
+import { Client } from '../../objects/client.js';
+
+export function showContactSelect() {
+    Client.loadContactSelect();
+}
+
+export function importSelectedContact(selectElement) {
+    Client.importSelectedContact(new DataTable('.tabledt'), selectElement);
+}

--- a/src/js/listener/main_listener.js
+++ b/src/js/listener/main_listener.js
@@ -29,6 +29,10 @@ import {
     updateEditableSelect,
     updateLinkedListSelection,
 } from './handlers/select_handlers.js';
+import {
+    importSelectedContact,
+    showContactSelect,
+} from './handlers/contact_handlers.js';
 
 let lastKeyEventTime = 0;
 
@@ -84,6 +88,10 @@ function handleBodyClick(event) {
     if (target.id === 'devisAdd') {
         addProductToDevis();
     }
+
+    if (target.id === 'importContactClient') {
+        showContactSelect();
+    }
 }
 
 function handleEditableOrCreationClick(event) {
@@ -119,6 +127,10 @@ function handleBodyDoubleClick(event) {
 
 function handleBodyChange(event) {
     const target = event.target;
+
+    if (target.id === 'contactClientSelect') {
+        importSelectedContact(target);
+    }
 
     if (target.classList.contains('listClient') || target.classList.contains('listDevis')) {
         updateLinkedListSelection(target);

--- a/src/js/objects/client.js
+++ b/src/js/objects/client.js
@@ -5,6 +5,8 @@ import { showSuccess, showError } from "@nextcloud/dialogs";
 
 export class Client {
 
+  static contacts = [];
+
   /**
    * 
    * @param myresp instantiate client object
@@ -79,6 +81,97 @@ export class Client {
       }
     };
     oReq.send();
+  }
+
+  static loadContactSelect() {
+    const selectElement = document.getElementById('contactClientSelect');
+    const importButton = document.getElementById('importContactClient');
+
+    selectElement.disabled = true;
+    importButton.disabled = true;
+
+    fetch(baseUrl + '/contacts', {
+      method: 'GET',
+      headers: csrfHeaders({
+        'Content-Type': 'application/json'
+      })
+    })
+    .then(response => {
+      if (!response.ok) {
+        throw response;
+      }
+      return response.json();
+    })
+    .then(contacts => {
+      Client.contacts = contacts;
+      selectElement.innerHTML = '';
+
+      const placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.text = t('gestion', 'Select a Nextcloud contact');
+      selectElement.appendChild(placeholder);
+
+      contacts.forEach((contact, index) => {
+        const option = document.createElement('option');
+        option.value = index.toString();
+        option.text = contact.label;
+        selectElement.appendChild(option);
+      });
+
+      selectElement.style.display = 'inline-block';
+      selectElement.disabled = false;
+
+      if (contacts.length === 0) {
+        showError(t('gestion', 'No contacts found'));
+      }
+    })
+    .catch(error => {
+      showError(Client.getRequestError(error));
+    })
+    .finally(() => {
+      importButton.disabled = false;
+    });
+  }
+
+  static importSelectedContact(dt, selectElement) {
+    const selectedContact = Client.contacts[Number.parseInt(selectElement.value, 10)];
+
+    if (!selectedContact) {
+      return;
+    }
+
+    selectElement.disabled = true;
+
+    fetch(baseUrl + '/client/insert-from-contact', {
+      method: 'POST',
+      headers: csrfHeaders({
+        'Content-Type': 'application/json'
+      }),
+      body: JSON.stringify(selectedContact)
+    })
+    .then(response => {
+      if (!response.ok) {
+        throw response;
+      }
+
+      showSuccess(t('gestion', 'Customer created from Nextcloud contact'));
+      selectElement.style.display = 'none';
+      selectElement.value = '';
+      Client.contacts = [];
+      Client.loadClientDT(dt);
+    })
+    .catch(error => {
+      selectElement.disabled = false;
+      showError(Client.getRequestError(error));
+    });
+  }
+
+  static getRequestError(error) {
+    if (error instanceof Response) {
+      return t('gestion', 'The request failed with status {status}', { status: error.status });
+    }
+
+    return error instanceof Error ? error.message : String(error);
   }
 
   /**

--- a/templates/content/index.php
+++ b/templates/content/index.php
@@ -5,6 +5,9 @@
         <span><?php p($l->t('Customer'));?></span>
         <span class="material-symbols-outlined">chevron_right</span>
         <button style="margin-left:3px;" type="button"  id="newClient"><?php p($l->t('Add customer'));?></button>
+        <button style="margin-left:3px;" type="button" id="importContactClient"><?php p($l->t('Add from Nextcloud contacts'));?></button>
+        <label class="hidden-visually" for="contactClientSelect"><?php p($l->t('Nextcloud contact'));?></label>
+        <select style="margin-left:3px;display:none;" id="contactClientSelect" disabled><option value=""><?php p($l->t('Select a Nextcloud contact'));?></option></select>
     </div>
     <table id="client" class="display tabledt" style="font-size:11px;">
         <thead>


### PR DESCRIPTION
### Motivation
- Add the ability to import Nextcloud Contacts into the app's customer list to simplify client creation and reduce manual entry.
- Provide a UI flow to browse Nextcloud contacts and create a customer from a selected contact.

### Description
- Added two new routes: `GET /contacts` and `POST /client/insert-from-contact` in `appinfo/routes.php` to expose contacts search and import endpoints.
- Introduced controller endpoints `getContacts` and `insertClientFromContact` in `lib/Controller/ClientController.php` that delegate to the service layer.
- Extended `DataService` to accept a `ContactsManager`, implemented `getContacts` which queries the Contacts API (limit 100) and maps contact fields to the client payload, and added `insertClientFromContact` which calls the DB layer; mapping helpers `mapContactToClient`, `firstValue`, and `firstString` were added to normalize vCard fields.
- Modified DB layer `lib/Db/Bdd.php` to centralize client insertion via `insertClientFromData`, added `sanitizeClientValue` and used `normalizeColumnData` for `zip_code` and `country_code`, and updated `insertClient` to call the new helper with default placeholders.
- Frontend changes include a small handler module `src/js/listener/handlers/contact_handlers.js`, updates to `src/js/listener/main_listener.js` to handle the import UI, and enhancements to `src/js/objects/client.js` with `loadContactSelect`, `importSelectedContact`, a `contacts` cache, and request error handling; the customer list template `templates/content/index.php` was updated to add the `Add from Nextcloud contacts` button and select control.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a723f86f42483328c6b2b90bff7af74)