### PR TITLE
Display the app version dynamically

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -133,8 +133,17 @@
 }
 
 .vat-exemption-reason-action {
-    min-width: var(--default-clickable-area, 44px);
+    min-width: 30px;
+    min-height: 30px;
+    width: 30px;
+    height: 30px;
+    padding: 2px;
     margin-right: var(--gestion-spacing-xs);
+}
+
+.vat-exemption-reason-action .material-symbols-outlined {
+    margin-right: 0;
+    font-size: 20px;
 }
 
 
@@ -151,6 +160,13 @@
 
 .app-navigation-item {
     margin-top: 15px;
+}
+
+.gestion-version {
+    padding: var(--gestion-spacing-md);
+    color: var(--gestion-text-muted);
+    font-size: var(--gestion-font-size-small);
+    text-align: center;
 }
 
 .nav-link,

--- a/lib/Service/TemplateService.php
+++ b/lib/Service/TemplateService.php
@@ -1,11 +1,13 @@
 <?php
 namespace OCA\Gestion\Service;
 
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\TemplateResponse;
 
 class TemplateService {
 	private $userId;
+	private IAppManager $appManager;
 	private CompanyService $companyService;
 	private DataService $dataService;
 	private FileService $fileService;
@@ -14,6 +16,7 @@ class TemplateService {
 
 	public function __construct(
 		$UserId,
+		IAppManager $appManager,
 		CompanyService $companyService,
 		DataService $dataService,
 		FileService $fileService,
@@ -21,6 +24,7 @@ class TemplateService {
 		ContentSecurityPolicy $csp
 	) {
 		$this->userId = $UserId;
+		$this->appManager = $appManager;
 		$this->companyService = $companyService;
 		$this->dataService = $dataService;
 		$this->fileService = $fileService;
@@ -31,6 +35,7 @@ class TemplateService {
 	private function baseParams(): array {
 		return [
 			'path' => $this->userId,
+			'appVersion' => $this->appManager->getAppVersion('gestion'),
 			'url' => $this->navigationService->getNavigationLink(),
 			'CompaniesList' => $this->companyService->getCompaniesList(),
 			'CurrentCompany' => $this->companyService->getCurrentCompany(),

--- a/src/css/mycss.less
+++ b/src/css/mycss.less
@@ -104,6 +104,27 @@ table.dataTable.display tbody tr.even > [class*="sorting_"] {
   font-feature-settings: 'liga';
 }
 
+.vat-exemption-reason-action {
+  min-width: 30px;
+  min-height: 30px;
+  width: 30px;
+  height: 30px;
+  padding: 2px;
+  margin-right: 4px;
+
+  .material-symbols-outlined {
+    margin-right: 0;
+    font-size: 20px;
+  }
+}
+
+.gestion-version {
+  padding: 12px;
+  color: #5f6368;
+  font-size: 12px;
+  text-align: center;
+}
+
 .material-symbols {
   font-family: 'Material Icons';
   font-size: 20px;

--- a/templates/content/changelog.php
+++ b/templates/content/changelog.php
@@ -1,7 +1,7 @@
 <div syle="display: none;" id="modalConfig" class="modal">
 <div class="modal-content">
 	<span class="modalClose">&times;</span>
-	<h2><?php p($l->t('Welcome to GESTION')); ?> 3.2.8</h2>
+	<h2><?php p($l->t('Welcome to GESTION')); ?> <?php p($_['appVersion']); ?></h2>
 
 	<p style="font-size:14px;margin-bottom:20px;">
 		<b><?php p($l->t('To start with this application you need to configure your company information, follow this link')); ?></b> 
@@ -39,7 +39,7 @@
 
 	<hr/>
 	<h2><?php p($l->t('Changelog')); ?></h2>
-	<h3>Version 3.2.8</h3>
+	<h3><?php p($l->t('Version')); ?> <?php p($_['appVersion']); ?></h3>
 	<p style="font-size:14px;"><?php p($l->t('This version focuses on electronic invoicing and prepares Gestion for the French e-invoicing transition.')); ?></p>
 	<p><a href="https://github.com/baimard/gestion/releases"><?php p($l->t('Releases')); ?></a></p>
 

--- a/templates/navigation/index.php
+++ b/templates/navigation/index.php
@@ -61,4 +61,7 @@
 	
 	<li><center><a href="#"><button id="about" style="margin-left:10px;width:270px;"><?php p($l->t('About'));?></button></a></center></li>
 	<li><center><a href="<?= ($_['url']['config']); ?>"><button style="margin-left:10px;width:270px;"><?php p($l->t('My company'));?></button></a></center></li>
+	<li class="gestion-version">
+		<?php p($l->t('Gestion version')); ?> <?php p($_['appVersion']); ?>
+	</li>
 </ul>


### PR DESCRIPTION
## What changed

- reads the installed Gestion version through Nextcloud's `IAppManager`
- exposes that version to every page through the shared template parameters
- replaces the two hard-coded changelog versions with the dynamic value
- displays `Gestion version …` at the bottom of the navigation menu
- reduces the VAT exemption-reason action to a 30 × 30 px button with a 20 px icon

Translation catalogs remain untouched because they are managed through Transifex.

## Why

`appinfo/info.xml` should be the single source of truth for the application version. Changing its `<version>` value now updates the changelog and navigation automatically at runtime.

The smaller VAT exemption action keeps the product actions column compact.

## Validation

- PHP syntax checks
- Nextcloud dependency-injection container resolves `TemplateService`
- runtime app version matches `appinfo/info.xml` (`3.2.10`)
- webpack production build
- template script verification
- no hard-coded `3.2.8` remains in the changelog
- no `l10n/` or Transifex files changed