### PR TITLE
Add direct PDF, Factur-X and XML actions to document lists

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -43,6 +43,8 @@ return [
         ['name' => 'stats#getServerFromMail', 'url' => '/getServerFromMail', 'verb' => 'PROPFIND'],
 
         ['name' => 'pdf#sendPDF', 'url' => '/sendPDF', 'verb' => 'POST'],
+        ['name' => 'pdf#personalMailStatus', 'url' => '/personal-mail/status', 'verb' => 'GET'],
+        ['name' => 'pdf#sendPersonalMail', 'url' => '/personal-mail/send', 'verb' => 'POST'],
         ['name' => 'pdf#savePDF', 'url' => '/savePDF', 'verb' => 'POST'],
 
         ['name' => 'admin#backup', 'url' => '/backup', 'verb' => 'GET'],

--- a/lib/Controller/PdfController.php
+++ b/lib/Controller/PdfController.php
@@ -2,16 +2,44 @@
 namespace OCA\Gestion\Controller;
 
 use OCA\Gestion\Service\PdfService;
+use OCA\Gestion\Service\PersonalMailService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\Attribute\UseSession;
 use OCP\IRequest;
 
 class PdfController extends Controller {
 	private PdfService $pdfService;
 
-	public function __construct($AppName, IRequest $request, PdfService $pdfService) {
+	public function __construct($AppName, IRequest $request, PdfService $pdfService, PersonalMailService $personalMailService) {
 		parent::__construct($AppName, $request);
 		$this->pdfService = $pdfService;
+		$this->personalMailService = $personalMailService;
+	}
+
+	private PersonalMailService $personalMailService;
+
+	/** @NoAdminRequired */
+	#[UseSession]
+	public function personalMailStatus(): DataResponse {
+		return new DataResponse($this->personalMailService->getStatus());
+	}
+
+	/** @NoAdminRequired */
+	#[UseSession]
+	public function sendPersonalMail(string $html, string $name, string $subject, string $body, string $to): DataResponse {
+		try {
+			$this->personalMailService->sendPdf(
+				$this->pdfService->renderPdf($html),
+				$name,
+				$subject,
+				$body,
+				$to,
+			);
+			return new DataResponse(['status' => 'success']);
+		} catch (\Throwable $e) {
+			return new DataResponse(['status' => 'error', 'message' => $e->getMessage()], 400);
+		}
 	}
 
 	/**

--- a/lib/Service/PdfService.php
+++ b/lib/Service/PdfService.php
@@ -233,7 +233,7 @@ class PdfService {
 		}
 	}
 
-	private function renderPdf($html): string {
+	public function renderPdf($html): string {
 
 		$mpdf = new Mpdf([
 			'mode' => 'utf-8',

--- a/lib/Service/PersonalMailService.php
+++ b/lib/Service/PersonalMailService.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Gestion\Service;
+
+use OCP\App\IAppManager;
+use OCP\Mail\Provider\Address;
+use OCP\Mail\Provider\Attachment;
+use OCP\Mail\Provider\IManager;
+use OCP\Mail\Provider\IMessageSend;
+use OCP\Mail\Provider\IService;
+
+class PersonalMailService {
+	private const PROVIDER_ID = 'mail-application';
+
+	public function __construct(
+		private IAppManager $appManager,
+		private IManager $mailManager,
+		private string $UserId,
+	) {
+	}
+
+	public function getStatus(): array {
+		try {
+			$service = $this->findSendService();
+			if ($service === null) {
+				return ['available' => false];
+			}
+
+			return [
+				'available' => true,
+				'account' => [
+					'id' => $service->id(),
+					'label' => $service->getLabel(),
+					'address' => $service->getPrimaryAddress()->getAddress(),
+				],
+			];
+		} catch (\Throwable $e) {
+			return ['available' => false];
+		}
+	}
+
+	public function sendPdf(string $pdf, string $name, string $subject, string $body, string $to): void {
+		$service = $this->findSendService();
+		if ($service === null) {
+			throw new \RuntimeException('No personal Mail account is available.');
+		}
+
+		$recipient = filter_var(trim($to), FILTER_VALIDATE_EMAIL);
+		if ($recipient === false) {
+			throw new \InvalidArgumentException('The customer email address is missing or invalid.');
+		}
+
+		$message = $service->initiateMessage();
+		$message->setFrom($service->getPrimaryAddress());
+		$message->setTo(new Address($recipient));
+		$message->setSubject($subject);
+		$message->setBody($body, false);
+		$message->setAttachments(new Attachment($pdf, html_entity_decode($name), 'application/pdf'));
+
+		$service->sendMessage($message);
+	}
+
+	private function findSendService(): ?IService {
+		if (!$this->appManager->isEnabledForUser('mail')) {
+			return null;
+		}
+
+		$provider = $this->mailManager->findProviderById(self::PROVIDER_ID);
+		if ($provider === null) {
+			return null;
+		}
+
+		foreach ($provider->listServices($this->UserId) as $service) {
+			if ($service instanceof IMessageSend && $service->capable('MessageSend')) {
+				return $service;
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/css/mycss.less
+++ b/src/css/mycss.less
@@ -150,6 +150,72 @@ table.dataTable.display tbody tr.even > [class*="sorting_"] {
   cursor: pointer; /* Change cursor to clickable */
 }
 
+.document-actions {
+  position: relative;
+  display: inline-block;
+
+  > summary {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border-radius: var(--border-radius-element);
+    cursor: pointer;
+    list-style: none;
+    user-select: none;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &:hover,
+    &:focus-visible {
+      background-color: var(--color-background-hover);
+    }
+  }
+}
+
+.document-actions-menu {
+  position: absolute;
+  z-index: 1000;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 190px;
+  padding: 4px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-large);
+  background-color: var(--color-main-background);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 20%);
+}
+
+.document-action {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 36px;
+  margin: 0;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: var(--border-radius-element);
+  background: transparent;
+  color: var(--color-main-text);
+  font: inherit;
+  text-align: left;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    background-color: var(--color-background-hover);
+  }
+
+  .material-symbols {
+    flex: 0 0 auto;
+  }
+}
+
 .menu-content {
   font-size:20px;
   margin-bottom: 10px;

--- a/src/css/mycss.less
+++ b/src/css/mycss.less
@@ -153,14 +153,23 @@ table.dataTable.display tbody tr.even > [class*="sorting_"] {
 .document-actions {
   position: relative;
   display: inline-block;
+  line-height: 1;
+  white-space: normal;
+
+  &[open] {
+    z-index: 1000;
+  }
 
   > summary {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 34px;
-    height: 34px;
+    width: 28px;
+    height: 28px;
+    margin: 0;
+    padding: 0;
     border-radius: var(--border-radius-element);
+    box-sizing: border-box;
     cursor: pointer;
     list-style: none;
     user-select: none;
@@ -179,40 +188,55 @@ table.dataTable.display tbody tr.even > [class*="sorting_"] {
 .document-actions-menu {
   position: absolute;
   z-index: 1000;
-  top: calc(100% + 4px);
+  top: calc(100% + 2px);
   right: 0;
-  min-width: 190px;
-  padding: 4px;
+  display: grid;
+  width: max-content;
+  min-width: 160px;
+  max-width: 210px;
+  padding: 3px;
+  gap: 1px;
   border: 1px solid var(--color-border);
-  border-radius: var(--border-radius-large);
+  border-radius: var(--border-radius-element);
   background-color: var(--color-main-background);
-  box-shadow: 0 4px 16px rgb(0 0 0 / 20%);
+  box-shadow: 0 3px 10px rgb(0 0 0 / 18%);
+  line-height: 1.2;
+  white-space: normal;
 }
 
-.document-action {
+.document-actions-menu .document-action {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 7px;
   width: 100%;
-  min-height: 36px;
-  margin: 0;
-  padding: 6px 10px;
-  border: 0;
+  min-width: 0;
+  min-height: 32px;
+  height: 32px;
+  margin: 0 !important;
+  padding: 4px 7px !important;
+  border: 0 !important;
   border-radius: var(--border-radius-element);
-  background: transparent;
-  color: var(--color-main-text);
+  box-sizing: border-box;
+  background: transparent !important;
+  color: var(--color-main-text) !important;
   font: inherit;
+  font-weight: normal;
   text-align: left;
+  text-decoration: none;
   white-space: nowrap;
   cursor: pointer;
+  appearance: none;
 
   &:hover,
   &:focus-visible {
-    background-color: var(--color-background-hover);
+    background-color: var(--color-background-hover) !important;
   }
 
   .material-symbols {
     flex: 0 0 auto;
+    width: 18px;
+    font-size: 18px;
+    text-align: center;
   }
 }
 

--- a/src/js/devis.js
+++ b/src/js/devis.js
@@ -6,8 +6,10 @@ import "./listener/main_listener";
 import DataTable from "datatables.net";
 import { globalConfiguration, optionDatatable } from "./modules/mainFunction.js";
 import { Devis } from "./objects/devis.js";
+import { bindDirectPdfDownloads } from "./pdf.js";
 
 window.addEventListener("DOMContentLoaded", function () {
     globalConfiguration();
+    bindDirectPdfDownloads();
     Devis.loadDevisDT(new DataTable(".tabledt",optionDatatable));
 });

--- a/src/js/devisShow.js
+++ b/src/js/devisShow.js
@@ -10,9 +10,16 @@ import { capture, sendMail } from "./pdf";
 window.addEventListener("DOMContentLoaded", function () {
     globalConfiguration();
 
-    Client.getClientByIdDevis(document.getElementById("devisid").dataset.id);
-    getProduitsById();
+    const documentReady = Promise.all([
+        Client.getClientByIdDevis(document.getElementById("devisid").dataset.id),
+        getProduitsById(),
+    ]);
 
     var pdf = document.getElementById("pdf");
     pdf.addEventListener("click",function(){capture(saveNextcloud);});
+
+    documentReady.then(() => {
+        document.documentElement.dataset.gestionDocumentReady = "true";
+        document.dispatchEvent(new CustomEvent("gestion:document-ready"));
+    });
 });

--- a/src/js/facture.js
+++ b/src/js/facture.js
@@ -6,10 +6,12 @@ import DataTable from "datatables.net";
 import { globalConfiguration, optionDatatable } from "./modules/mainFunction.js";
 import "./listener/main_listener";
 import { Facture } from "./objects/facture.js";
+import { bindDirectPdfDownloads } from "./pdf.js";
 // import { Devis } from './objects/devis.mjs';
 
 window.addEventListener("DOMContentLoaded", function () {
     globalConfiguration();
+    bindDirectPdfDownloads();
     var dt = new DataTable(".tabledt",optionDatatable);
     Facture.loadFactureDT(dt);
 });

--- a/src/js/factureShow.js
+++ b/src/js/factureShow.js
@@ -11,8 +11,10 @@ import { capture, captureFacturX, captureFacturXml, sendFacturXToIopole, sendMai
 window.addEventListener("DOMContentLoaded", function () {
     globalConfiguration();
 
-    Client.getClientByIdDevis(document.getElementById("devisid").dataset.id);
-    getProduitsById();
+    const documentReady = Promise.all([
+        Client.getClientByIdDevis(document.getElementById("devisid").dataset.id),
+        getProduitsById(),
+    ]);
 
     // Bouton 1 — Sauvegarder dans Nextcloud (pdf)
     var pdf = document.getElementById("pdf");
@@ -35,5 +37,9 @@ window.addEventListener("DOMContentLoaded", function () {
     if (facturxIopole) {
         facturxIopole.addEventListener("click", function(){ sendFacturXToIopole(); });
     }
-    
+
+    documentReady.then(() => {
+        document.documentElement.dataset.gestionDocumentReady = "true";
+        document.dispatchEvent(new CustomEvent("gestion:document-ready"));
+    });
 });

--- a/src/js/listener/main_listener.js
+++ b/src/js/listener/main_listener.js
@@ -50,6 +50,20 @@ function registerMainListeners() {
 
 function handleBodyClick(event) {
     const target = event.target;
+    const actionMenu = target.closest?.('.document-actions');
+    const actionMenuSummary = target.closest?.('.document-actions > summary');
+    const duplicateAction = target.closest?.('.duplicateItem');
+    const deleteAction = target.closest?.('.deleteItem');
+
+    if (actionMenuSummary) {
+        document.querySelectorAll('.document-actions[open]').forEach(menu => {
+            if (menu !== actionMenu) {
+                menu.removeAttribute('open');
+            }
+        });
+    } else if (!actionMenu) {
+        document.querySelectorAll('.document-actions[open]').forEach(menu => menu.removeAttribute('open'));
+    }
     const vatExemptionAction = target.closest?.('.vat-exemption-reason-action');
 
     if (vatExemptionAction) {
@@ -81,8 +95,9 @@ function handleBodyClick(event) {
         closeModal(target);
     }
 
-    if (target.classList.contains('duplicateItem')) {
-        duplicateItem(target);
+    if (duplicateAction) {
+        actionMenu?.removeAttribute('open');
+        duplicateItem(duplicateAction);
     }
 
     if (target.classList.contains('drop_down')) {
@@ -93,8 +108,9 @@ function handleBodyClick(event) {
         dropItem(target, 'up');
     }
 
-    if (target.classList.contains('deleteItem')) {
-        deleteItem(target);
+    if (deleteAction) {
+        actionMenu?.removeAttribute('open');
+        deleteItem(deleteAction);
     }
 
     if (target.id === 'devisAdd') {
@@ -160,6 +176,16 @@ async function handleBodyChange(event) {
 }
 
 function handleBodyKeydown(event) {
+    if (event.key === 'Escape') {
+        const openActionMenu = event.target.closest?.('.document-actions[open]');
+
+        if (openActionMenu) {
+            openActionMenu.removeAttribute('open');
+            openActionMenu.querySelector('summary')?.focus();
+            return;
+        }
+    }
+
     if (event.key !== "Enter") {
         return;
     }

--- a/src/js/modules/ajaxRequest.js
+++ b/src/js/modules/ajaxRequest.js
@@ -474,7 +474,7 @@ export function getProduitsById() {
     const devis_id = document.getElementById('devisid').dataset.id;
     const myData = { numdevis: devis_id };
 
-    fetch(baseUrl + '/getProduitsById', {
+    return fetch(baseUrl + '/getProduitsById', {
         method: 'POST',
         headers: csrfHeaders({
             'Content-Type': 'application/json'
@@ -600,7 +600,7 @@ export function getProduitsById() {
             </tr>
         `;
 
-        getGlobal();
+        return getGlobal();
     })
     .catch(error => {
         showError(error);

--- a/src/js/modules/ajaxRequest.js
+++ b/src/js/modules/ajaxRequest.js
@@ -636,7 +636,7 @@ export function saveNextcloud(myData) {
   };
 
 export function generateFacturXmlRequest(factureId, name, folder) {
-    fetch(baseUrl + '/generateFacturXml', {
+    return fetch(baseUrl + '/generateFacturXml', {
         method: 'POST',
         headers: csrfHeaders({
             'Content-Type': 'application/json'

--- a/src/js/modules/mainFunction.js
+++ b/src/js/modules/mainFunction.js
@@ -242,7 +242,7 @@ const options = {
 };
 
 
-fetch(url, options)
+return fetch(url, options)
     .then(response => response.json())
     .then(data => {
         const myresp = JSON.parse(data)[0];

--- a/src/js/objects/client.js
+++ b/src/js/objects/client.js
@@ -107,7 +107,7 @@ export class Client {
   static getClientByIdDevis(id) {
     const myData = { id: id };
 
-    fetch(baseUrl + '/clientbyiddevis', {
+    return fetch(baseUrl + '/clientbyiddevis', {
       method: 'POST',
       headers: csrfHeaders({
         'Content-Type': 'application/json'

--- a/src/js/objects/devis.js
+++ b/src/js/objects/devis.js
@@ -34,12 +34,15 @@ export class Devis {
       `<div class="loadSelect_listclient" data-table="devis" data-column="id_client" data-id="${this.id}" data-current="${this.cid}">${this.entreprise} - ${this.prenom} ${this.nom}</div>`,
       `<div class="inline editable" data-table="devis" data-column="version" data-id="${this.id}">${this.version}</div>`,
       `<div class="inline editable" data-table="devis" data-column="mentions" data-id="${this.id}" >${this.mentions}</div>`,
-      `<div class="material-symbols">
-        <span title="${t('gestion', 'Open')}"><a href="${this.baseUrl}">open_in_new</a></span>
-        <span title="${t('gestion', 'Download PDF')}" aria-label="${t('gestion', 'Download PDF')}" data-url="${this.baseUrl}" class="link downloadDocumentPdf">download</span>
-        <span title="${t('gestion', 'Duplicate')}" data-modifier="devis" data-id=${this.id} data-table="devis" class="link duplicateItem">content_copy</span>
-        <span title="${t('gestion', 'Delete')}" data-modifier="devis" data-id=${this.id} data-table="devis" class="link deleteItem">delete</span>
-      </div>`
+      `<details class="document-actions">
+        <summary title="${t('gestion', 'Actions')}" aria-label="${t('gestion', 'Actions')}" class="material-symbols">more_horiz</summary>
+        <div class="document-actions-menu">
+          <a href="${this.baseUrl}" class="document-action"><span class="material-symbols">open_in_new</span><span>${t('gestion', 'Open')}</span></a>
+          <button type="button" data-url="${this.baseUrl}" class="document-action downloadDocumentPdf"><span class="material-symbols">download</span><span>${t('gestion', 'Download PDF')}</span></button>
+          <button type="button" data-modifier="devis" data-id="${this.id}" data-table="devis" class="document-action duplicateItem"><span class="material-symbols">content_copy</span><span>${t('gestion', 'Duplicate')}</span></button>
+          <button type="button" data-modifier="devis" data-id="${this.id}" data-table="devis" class="document-action deleteItem"><span class="material-symbols">delete</span><span>${t('gestion', 'Delete')}</span></button>
+        </div>
+      </details>`
     ];
     return myrow;
   }

--- a/src/js/objects/devis.js
+++ b/src/js/objects/devis.js
@@ -36,6 +36,7 @@ export class Devis {
       `<div class="inline editable" data-table="devis" data-column="mentions" data-id="${this.id}" >${this.mentions}</div>`,
       `<div class="material-symbols">
         <span title="${t('gestion', 'Open')}"><a href="${this.baseUrl}">open_in_new</a></span>
+        <span title="${t('gestion', 'Download PDF')}" aria-label="${t('gestion', 'Download PDF')}" data-url="${this.baseUrl}" class="link downloadDocumentPdf">download</span>
         <span title="${t('gestion', 'Duplicate')}" data-modifier="devis" data-id=${this.id} data-table="devis" class="link duplicateItem">content_copy</span>
         <span title="${t('gestion', 'Delete')}" data-modifier="devis" data-id=${this.id} data-table="devis" class="link deleteItem">delete</span>
       </div>`

--- a/src/js/objects/devis.js
+++ b/src/js/objects/devis.js
@@ -39,6 +39,7 @@ export class Devis {
         <div class="document-actions-menu">
           <a href="${this.baseUrl}" class="document-action"><span class="material-symbols">open_in_new</span><span>${t('gestion', 'Open')}</span></a>
           <button type="button" data-url="${this.baseUrl}" class="document-action downloadDocumentPdf"><span class="material-symbols">download</span><span>${t('gestion', 'Download PDF')}</span></button>
+          <button type="button" data-url="${this.baseUrl}" class="document-action sendDocumentMail"><span class="material-symbols">mail</span><span>${t('gestion', 'Send by email')}</span></button>
           <button type="button" data-modifier="devis" data-id="${this.id}" data-table="devis" class="document-action duplicateItem"><span class="material-symbols">content_copy</span><span>${t('gestion', 'Duplicate')}</span></button>
           <button type="button" data-modifier="devis" data-id="${this.id}" data-table="devis" class="document-action deleteItem"><span class="material-symbols">delete</span><span>${t('gestion', 'Delete')}</span></button>
         </div>

--- a/src/js/objects/facture.js
+++ b/src/js/objects/facture.js
@@ -75,6 +75,7 @@ export class Facture {
         <div class="document-actions-menu">
           <a href="${this.baseUrl}" class="document-action"><span class="material-symbols">open_in_new</span><span>${t('gestion', 'Open')}</span></a>
           <button type="button" data-url="${this.baseUrl}" class="document-action downloadDocumentPdf"><span class="material-symbols">download</span><span>${t('gestion', 'Download PDF')}</span></button>
+          <button type="button" data-url="${this.baseUrl}" class="document-action sendDocumentMail"><span class="material-symbols">mail</span><span>${t('gestion', 'Send by email')}</span></button>
           <button type="button" data-url="${this.baseUrl}" class="document-action downloadFacturX"><span class="material-symbols">receipt_long</span><span>${t('gestion', 'Factur-X PDF + XML')}</span></button>
           <button type="button" data-url="${this.baseUrl}" class="document-action downloadFacturXml"><span class="material-symbols">data_object</span><span>${t('gestion', 'Factur-X XML')}</span></button>
           <button type="button" data-modifier="facture" data-id="${this.id}" data-table="facture" class="document-action duplicateItem"><span class="material-symbols">content_copy</span><span>${t('gestion', 'Duplicate')}</span></button>

--- a/src/js/objects/facture.js
+++ b/src/js/objects/facture.js
@@ -70,12 +70,15 @@ export class Facture {
       `<div class="loadSelect_listdevis" data-table="facture" data-column="id_devis" data-id="${this.id}" data-current="${this.id_devis}">${this.dnum} ${this.prenom} ${this.nom}</div>`,
       `<div class="editable" data-table="facture" data-column="version" data-id="${this.id}" style="display:inline">${this.version}</div>`,
       `<div class="editable" data-table="facture" data-column="status_paiement" data-id="${this.id}" style="display:inline">${this.status_paiement}</div>`,
-      `<div class="material-symbols">
-        <span title="${t('gestion', 'Open')}"><a href="${this.baseUrl}">open_in_new</a></span>
-        <span title="${t('gestion', 'Download PDF')}" aria-label="${t('gestion', 'Download PDF')}" data-url="${this.baseUrl}" class="link downloadDocumentPdf">download</span>
-        <span title="${t('gestion', 'Duplicate')}" data-modifier="facture" data-id=${this.id} data-table="facture" class="link duplicateItem">content_copy</span>
-        <span title="${t('gestion', 'Delete')}" data-modifier="facture" data-id=${this.id} data-table="facture" class="link deleteItem">delete</span>
-      </div>`
+      `<details class="document-actions">
+        <summary title="${t('gestion', 'Actions')}" aria-label="${t('gestion', 'Actions')}" class="material-symbols">more_horiz</summary>
+        <div class="document-actions-menu">
+          <a href="${this.baseUrl}" class="document-action"><span class="material-symbols">open_in_new</span><span>${t('gestion', 'Open')}</span></a>
+          <button type="button" data-url="${this.baseUrl}" class="document-action downloadDocumentPdf"><span class="material-symbols">download</span><span>${t('gestion', 'Download PDF')}</span></button>
+          <button type="button" data-modifier="facture" data-id="${this.id}" data-table="facture" class="document-action duplicateItem"><span class="material-symbols">content_copy</span><span>${t('gestion', 'Duplicate')}</span></button>
+          <button type="button" data-modifier="facture" data-id="${this.id}" data-table="facture" class="document-action deleteItem"><span class="material-symbols">delete</span><span>${t('gestion', 'Delete')}</span></button>
+        </div>
+      </details>`
     ];
     return myrow;
   }

--- a/src/js/objects/facture.js
+++ b/src/js/objects/facture.js
@@ -72,6 +72,7 @@ export class Facture {
       `<div class="editable" data-table="facture" data-column="status_paiement" data-id="${this.id}" style="display:inline">${this.status_paiement}</div>`,
       `<div class="material-symbols">
         <span title="${t('gestion', 'Open')}"><a href="${this.baseUrl}">open_in_new</a></span>
+        <span title="${t('gestion', 'Download PDF')}" aria-label="${t('gestion', 'Download PDF')}" data-url="${this.baseUrl}" class="link downloadDocumentPdf">download</span>
         <span title="${t('gestion', 'Duplicate')}" data-modifier="facture" data-id=${this.id} data-table="facture" class="link duplicateItem">content_copy</span>
         <span title="${t('gestion', 'Delete')}" data-modifier="facture" data-id=${this.id} data-table="facture" class="link deleteItem">delete</span>
       </div>`

--- a/src/js/objects/facture.js
+++ b/src/js/objects/facture.js
@@ -75,6 +75,8 @@ export class Facture {
         <div class="document-actions-menu">
           <a href="${this.baseUrl}" class="document-action"><span class="material-symbols">open_in_new</span><span>${t('gestion', 'Open')}</span></a>
           <button type="button" data-url="${this.baseUrl}" class="document-action downloadDocumentPdf"><span class="material-symbols">download</span><span>${t('gestion', 'Download PDF')}</span></button>
+          <button type="button" data-url="${this.baseUrl}" class="document-action downloadFacturX"><span class="material-symbols">receipt_long</span><span>${t('gestion', 'Factur-X PDF + XML')}</span></button>
+          <button type="button" data-url="${this.baseUrl}" class="document-action downloadFacturXml"><span class="material-symbols">data_object</span><span>${t('gestion', 'Factur-X XML')}</span></button>
           <button type="button" data-modifier="facture" data-id="${this.id}" data-table="facture" class="document-action duplicateItem"><span class="material-symbols">content_copy</span><span>${t('gestion', 'Duplicate')}</span></button>
           <button type="button" data-modifier="facture" data-id="${this.id}" data-table="facture" class="document-action deleteItem"><span class="material-symbols">delete</span><span>${t('gestion', 'Delete')}</span></button>
         </div>

--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -87,7 +87,7 @@ export function capture(afterCapturefunction, sourceDocument = document) {
  */
 export function bindDirectPdfDownloads() {
   document.addEventListener("click", event => {
-    const trigger = event.target.closest(".downloadDocumentPdf");
+    const trigger = event.target.closest(".downloadDocumentPdf, .downloadFacturX, .downloadFacturXml");
 
     if (!trigger || trigger.dataset.loading === "true") {
       return;
@@ -98,7 +98,14 @@ export function bindDirectPdfDownloads() {
     trigger.dataset.loading = "true";
     trigger.setAttribute("aria-busy", "true");
 
-    downloadPdfFromDetailPage(trigger.dataset.url)
+    let format = "pdf";
+    if (trigger.classList.contains("downloadFacturX")) {
+      format = "facturx";
+    } else if (trigger.classList.contains("downloadFacturXml")) {
+      format = "xml";
+    }
+
+    downloadFromDetailPage(trigger.dataset.url, format)
       .catch(error => {
         console.error("Direct PDF generation error:", error);
         showMessage(t("gestion", "Error when creating PDF."));
@@ -110,7 +117,7 @@ export function bindDirectPdfDownloads() {
   });
 }
 
-function downloadPdfFromDetailPage(detailUrl) {
+function downloadFromDetailPage(detailUrl, format) {
   showMessage(t("gestion", "Creation in progress …"));
 
   const frame = document.createElement("iframe");
@@ -131,7 +138,16 @@ function downloadPdfFromDetailPage(detailUrl) {
       }
 
       window.clearTimeout(timeout);
-      capture(null, frameDocument).then(resolve).catch(reject);
+      let generation;
+      if (format === "facturx") {
+        generation = captureFacturX(frameDocument);
+      } else if (format === "xml") {
+        generation = captureFacturXml(frameDocument);
+      } else {
+        generation = capture(null, frameDocument);
+      }
+
+      generation.then(resolve).catch(reject);
     };
 
     frame.addEventListener("load", () => {
@@ -163,25 +179,25 @@ function downloadPdfFromDetailPage(detailUrl) {
  * Génère et télécharge un PDF Factur-X (EN 16931) pour la facture courante.
  * Le fichier est aussi sauvegardé dans Nextcloud.
  */
-export function captureFacturX() {
+export function captureFacturX(sourceDocument = document) {
   showMessage(t("gestion", "Generating the electronic invoice…"));
 
-  const pdfElement  = document.getElementById("pdf");
-  const facturxBtn  = document.getElementById("facturx");
+  const pdfElement  = sourceDocument.getElementById("pdf");
+  const facturxBtn  = sourceDocument.getElementById("facturx");
   const pdfName     = pdfElement.getAttribute("data-name");
-  const folder      = document.getElementById("theFolder").value;
+  const folder      = sourceDocument.getElementById("theFolder").value;
   const pdfFolder   = pdfElement.getAttribute("data-folder");
   const factureId   = parseInt(facturxBtn.getAttribute("data-factureid"), 10);
 
   // Clone du contenu sans les boutons (data-html2canvas-ignore)
-  const element       = document.querySelector("#PDFcontent");
+  const element       = sourceDocument.querySelector("#PDFcontent");
   const clonedElement = element.cloneNode(true);
   clonedElement.querySelectorAll('[data-html2canvas-ignore]').forEach(el => el.remove());
   const htmlContent = clonedElement.outerHTML;
 
   const name = t("gestion", "INVOICE") + "_" + pdfName + "_facturx.pdf";
 
-  fetch(baseUrl + '/generateFacturX', {
+  return fetch(baseUrl + '/generateFacturX', {
     method: 'POST',
     headers: csrfHeaders({
       'Content-Type': 'application/json'
@@ -218,19 +234,19 @@ export function captureFacturX() {
  * Génère et télécharge uniquement le XML Factur-X (CII EN 16931) pour la facture courante.
  * Le fichier est aussi sauvegardé dans Nextcloud.
  */
-export function captureFacturXml() {
+export function captureFacturXml(sourceDocument = document) {
   showMessage(t("gestion", "Generating Factur-X XML…"));
 
-  const pdfElement = document.getElementById("pdf");
-  const facturxBtn = document.getElementById("facturx-xml");
+  const pdfElement = sourceDocument.getElementById("pdf");
+  const facturxBtn = sourceDocument.getElementById("facturx-xml");
   const pdfName    = pdfElement.getAttribute("data-name");
-  const folder     = document.getElementById("theFolder").value;
+  const folder     = sourceDocument.getElementById("theFolder").value;
   const pdfFolder  = pdfElement.getAttribute("data-folder");
   const factureId  = parseInt(facturxBtn.getAttribute("data-factureid"), 10);
 
   const xmlFileName = t("gestion", "INVOICE") + "_" + pdfName + "_facturx.xml";
 
-  generateFacturXmlRequest(factureId, xmlFileName, folder + "/" + pdfFolder + "/");
+  return generateFacturXmlRequest(factureId, xmlFileName, folder + "/" + pdfFolder + "/");
 }
 
 /**

--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -25,28 +25,28 @@ export function sendMail(myData) {
   });
 }
 
-export function capture(afterCapturefunction) {
+export function capture(afterCapturefunction, sourceDocument = document) {
   showMessage(t("gestion", "Creation in progress …"));
   
-  const pdfElement = document.getElementById("pdf");
+  const pdfElement = sourceDocument.getElementById("pdf");
   const pdfName = pdfElement.getAttribute("data-name");
   
-  const folder = document.getElementById("theFolder").value;
+  const folder = sourceDocument.getElementById("theFolder").value;
   const pdfFolder = pdfElement.getAttribute("data-folder");
   
-  const element = document.querySelector("#PDFcontent");
+  const element = sourceDocument.querySelector("#PDFcontent");
   const clonedElement = element.cloneNode(true);
   clonedElement.querySelectorAll('[data-html2canvas-ignore]').forEach(el => el.remove());
   const htmlContent = clonedElement.outerHTML;
   
   let name = "";
-  if (document.getElementById("factureid")) {
+  if (sourceDocument.getElementById("factureid")) {
     name = t("gestion", "INVOICE") + "_" + pdfName + ".pdf";
   } else {
     name = t("gestion", "QUOTE") + "_" + pdfName + ".pdf";
   }
   
-  fetch(baseUrl + '/generatePDF', {
+  return fetch(baseUrl + '/generatePDF', {
     method: 'POST',
     headers: csrfHeaders({
       'Content-Type': 'application/json'
@@ -75,6 +75,86 @@ export function capture(afterCapturefunction) {
   .catch(error => {
     console.error("Errors during PDF generation :", error);
     showMessage(t("gestion", "Error when creating PDF."));
+  });
+}
+
+/**
+ * Bind the direct PDF action used by quote and invoice lists.
+ *
+ * The detail page is loaded in a hidden same-origin frame because it enriches
+ * the server-rendered document with customer, product, total and configuration
+ * data before the existing PDF endpoint is called.
+ */
+export function bindDirectPdfDownloads() {
+  document.addEventListener("click", event => {
+    const trigger = event.target.closest(".downloadDocumentPdf");
+
+    if (!trigger || trigger.dataset.loading === "true") {
+      return;
+    }
+
+    event.preventDefault();
+    trigger.dataset.loading = "true";
+    trigger.setAttribute("aria-busy", "true");
+
+    downloadPdfFromDetailPage(trigger.dataset.url)
+      .catch(error => {
+        console.error("Direct PDF generation error:", error);
+        showMessage(t("gestion", "Error when creating PDF."));
+      })
+      .finally(() => {
+        delete trigger.dataset.loading;
+        trigger.removeAttribute("aria-busy");
+      });
+  });
+}
+
+function downloadPdfFromDetailPage(detailUrl) {
+  showMessage(t("gestion", "Creation in progress …"));
+
+  const frame = document.createElement("iframe");
+  frame.hidden = true;
+  frame.setAttribute("aria-hidden", "true");
+  frame.title = t("gestion", "PDF generation");
+
+  return new Promise((resolve, reject) => {
+    const timeout = window.setTimeout(() => {
+      reject(new Error("Timed out while preparing the document"));
+    }, 30000);
+
+    const documentIsReady = () => {
+      const frameDocument = frame.contentDocument;
+
+      if (frameDocument?.documentElement.dataset.gestionDocumentReady !== "true") {
+        return;
+      }
+
+      window.clearTimeout(timeout);
+      capture(null, frameDocument).then(resolve).catch(reject);
+    };
+
+    frame.addEventListener("load", () => {
+      const frameDocument = frame.contentDocument;
+
+      if (!frameDocument) {
+        window.clearTimeout(timeout);
+        reject(new Error("Unable to load the document"));
+        return;
+      }
+
+      frameDocument.addEventListener("gestion:document-ready", documentIsReady, { once: true });
+      documentIsReady();
+    }, { once: true });
+
+    frame.addEventListener("error", () => {
+      window.clearTimeout(timeout);
+      reject(new Error("Unable to load the document"));
+    }, { once: true });
+
+    frame.src = detailUrl;
+    document.body.appendChild(frame);
+  }).finally(() => {
+    frame.remove();
   });
 }
 

--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -87,7 +87,7 @@ export function capture(afterCapturefunction, sourceDocument = document) {
  */
 export function bindDirectPdfDownloads() {
   document.addEventListener("click", event => {
-    const trigger = event.target.closest(".downloadDocumentPdf, .downloadFacturX, .downloadFacturXml");
+    const trigger = event.target.closest(".downloadDocumentPdf, .downloadFacturX, .downloadFacturXml, .sendDocumentMail");
 
     if (!trigger || trigger.dataset.loading === "true") {
       return;
@@ -105,16 +105,99 @@ export function bindDirectPdfDownloads() {
       format = "xml";
     }
 
-    downloadFromDetailPage(trigger.dataset.url, format)
+    const action = trigger.classList.contains("sendDocumentMail")
+      ? sendDocumentByMail(trigger.dataset.url)
+      : downloadFromDetailPage(trigger.dataset.url, format);
+
+    action
       .catch(error => {
         console.error("Direct PDF generation error:", error);
-        showMessage(t("gestion", "Error when creating PDF."));
+        showMessage(error.message || t("gestion", "The operation could not be completed."));
       })
       .finally(() => {
         delete trigger.dataset.loading;
         trigger.removeAttribute("aria-busy");
       });
   });
+}
+
+async function sendDocumentByMail(detailUrl) {
+  const statusResponse = await fetch(baseUrl + "/personal-mail/status", {
+    headers: csrfHeaders()
+  });
+  const status = statusResponse.ok ? await statusResponse.json() : { available: false };
+
+  if (!status.available) {
+    showMailPrerequisites();
+    return;
+  }
+
+  showMessage(t("gestion", "Preparing the email…"));
+  return withPreparedDocument(detailUrl, async sourceDocument => {
+    const pdfElement = sourceDocument.getElementById("pdf");
+    const pdfName = pdfElement.getAttribute("data-name");
+    const isInvoice = Boolean(sourceDocument.getElementById("factureid"));
+    const type = isInvoice ? t("gestion", "Invoice") : t("gestion", "Quote");
+    const name = (isInvoice ? t("gestion", "INVOICE") : t("gestion", "QUOTE")) + "_" + pdfName + ".pdf";
+    const recipient = sourceDocument.getElementById("mail")?.textContent?.trim() || "";
+    const element = sourceDocument.querySelector("#PDFcontent").cloneNode(true);
+    element.querySelectorAll("[data-html2canvas-ignore]").forEach(node => node.remove());
+
+    const response = await fetch(baseUrl + "/personal-mail/send", {
+      method: "POST",
+      headers: csrfHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify({
+        html: element.outerHTML,
+        name,
+        to: recipient,
+        subject: type + " " + pdfName,
+        body: t("gestion", "Hello,\n\nPlease find your document attached.\n\nKind regards.")
+      })
+    });
+
+    const result = await response.json();
+    if (!response.ok) {
+      throw new Error(result.message || t("gestion", "Email sending failed."));
+    }
+    showMessage(t("gestion", "Email sent"));
+  });
+}
+
+function showMailPrerequisites() {
+  const title = t("gestion", "Email sending unavailable");
+  const message = t("gestion", "To use this function, the Nextcloud Mail application must be installed and enabled. You must also configure a personal default email account and verify that it is connected and able to send messages.");
+
+  if (window.OC?.dialogs?.alert) {
+    window.OC.dialogs.alert(message, title);
+  } else {
+    window.alert(title + "\n\n" + message);
+  }
+}
+
+function withPreparedDocument(detailUrl, callback) {
+  const frame = document.createElement("iframe");
+  frame.hidden = true;
+  frame.setAttribute("aria-hidden", "true");
+  frame.title = t("gestion", "Document preparation");
+
+  return new Promise((resolve, reject) => {
+    const timeout = window.setTimeout(() => reject(new Error("Timed out while preparing the document")), 30000);
+    const ready = () => {
+      const sourceDocument = frame.contentDocument;
+      if (sourceDocument?.documentElement.dataset.gestionDocumentReady !== "true") return;
+      window.clearTimeout(timeout);
+      Promise.resolve(callback(sourceDocument)).then(resolve).catch(reject);
+    };
+    frame.addEventListener("load", () => {
+      const sourceDocument = frame.contentDocument;
+      if (!sourceDocument) return reject(new Error("Unable to load the document"));
+      sourceDocument.addEventListener("gestion:document-ready", ready, { once: true });
+      ready();
+    }, { once: true });
+    frame.addEventListener("error", () => reject(new Error("Unable to load the document")), { once: true });
+    frame.src = detailUrl;
+    document.body.appendChild(frame);
+  }).finally(() => frame.remove());
 }
 
 function downloadFromDetailPage(detailUrl, format) {

--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -94,6 +94,7 @@ export function bindDirectPdfDownloads() {
     }
 
     event.preventDefault();
+    trigger.closest(".document-actions")?.removeAttribute("open");
     trigger.dataset.loading = "true";
     trigger.setAttribute("aria-busy", "true");
 

--- a/templates/content/devis.php
+++ b/templates/content/devis.php
@@ -15,7 +15,7 @@
                 <th class="help-heading" title="<?php p($l->t('Select the customer receiving the quote. For French mandatory quotes, the customer name and address must be stated.'));?>"><?php p($l->t('Customer quote'));?></th>
                 <th class="help-heading" title="<?php p($l->t('Enter the revision number of the quote, for example 1.0 or 2.0. Increase it when issuing a materially revised quote.'));?>"><?php p($l->t('Version'));?></th>
                 <th class="help-heading" title="<?php p($l->t('Enter the current quote status, for example Draft, Sent, Accepted, Rejected or Expired. An accepted quote can become binding evidence of the agreement.'));?>"><?php p($l->t('Status'));?></th>
-                <th class="help-heading" title="<?php p($l->t('Use these buttons to open, duplicate or delete the quote. Keep accepted quotes for the retention period applicable to your business.'));?>"><?php p($l->t('Actions'));?></th>
+                <th class="help-heading" title="<?php p($l->t('Use the actions menu to open, download, duplicate or delete the quote. Keep accepted quotes for the retention period applicable to your business.'));?>"><?php p($l->t('Actions'));?></th>
             </tr>
         </thead>
         <tbody>

--- a/templates/content/facture.php
+++ b/templates/content/facture.php
@@ -17,7 +17,7 @@
                 <th class="help-heading" title="<?php p($l->t('Select the quote from which this invoice is created. This links the invoice to its accepted commercial terms and customer.'));?>"><?php p($l->t('Associated quote'));?></th>
                 <th class="help-heading" title="<?php p($l->t('Enter the internal document revision. Do not reuse or alter the legal number of an issued French invoice; issue a corrective document when required.'));?>"><?php p($l->t('Version'));?></th>
                 <th class="help-heading" title="<?php p($l->t('Enter the payment status, for example Pending, Paid, Partially paid, Overdue or Cancelled. Keep it consistent with the payment due date.'));?>"><?php p($l->t('Status'));?></th>
-                <th class="help-heading" title="<?php p($l->t('Use these buttons to open, duplicate or delete the invoice. In France, issued invoices are accounting records and must be retained; do not delete them to correct an error.'));?>"><?php p($l->t('Actions'));?></th>
+                <th class="help-heading" title="<?php p($l->t('Use the actions menu to open, download, duplicate or delete the invoice. In France, issued invoices are accounting records and must be retained; do not delete them to correct an error.'));?>"><?php p($l->t('Actions'));?></th>
             </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
## Résumé

- regroupe les actions derrière un menu compact « … » sur chaque devis et facture
- permet de télécharger directement le PDF standard depuis les deux listes
- ajoute aux factures la génération directe du PDF Factur-X avec XML embarqué et du XML seul
- ajoute une action « Envoyer par email » toujours visible pour les devis et factures
- vérifie au clic que Nextcloud Mail est activé et qu’un compte personnel capable d’envoyer est configuré
- utilise l’API publique Mail Provider de Nextcloud et le premier compte personnel disponible
- affiche une modale détaillant les prérequis lorsque Mail ou le compte personnel manque
- génère le PDF et l’envoie à l’adresse du client sans ouvrir la vue détail

## Choix technique

Le contenu du document étant enrichi côté navigateur par les vues détail, les actions chargent la facture ou le devis dans un cadre masqué de même origine et attendent le signal `gestion:document-ready`. L’envoi utilise exclusivement les interfaces publiques `OCP\Mail\Provider`, ce qui garde l’application Mail optionnelle et évite une dépendance directe envers ses classes internes.

## Validation

- `npm run build` — compilation réussie (avertissements de taille préexistants)
- `composer validate --no-check-publish`
- `composer install --dry-run --no-interaction --no-scripts`
- `composer audit --locked` — aucune vulnérabilité PHP
- `npm audit --offline` — aucune vulnérabilité JavaScript
- syntaxe PHP validée sur l’ensemble de `lib/`
- `git diff --check`
- PHPUnit local non exécutable sous l’utilisateur courant à cause des permissions Nextcloud ; sous `www-data`, la suite configurée ne sélectionne aucun test
- ESLint autonome indisponible : le dépôt ne contient pas de configuration ESLint 9

Closes #597.
