### PR TITLE
Add email confirmation dialog before sending documents

### DIFF
--- a/src/css/mycss.less
+++ b/src/css/mycss.less
@@ -240,6 +240,64 @@ table.dataTable.display tbody tr.even > [class*="sorting_"] {
   }
 }
 
+.gestion-mail-dialog {
+  width: min(520px, calc(100vw - 32px));
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-large);
+  background: var(--color-main-background);
+  color: var(--color-main-text);
+  box-shadow: 0 8px 30px rgb(0 0 0 / 28%);
+
+  &::backdrop {
+    background: rgb(0 0 0 / 45%);
+  }
+}
+
+.gestion-mail-dialog-form {
+  display: grid;
+  gap: 14px;
+  padding: 20px;
+
+  h2 {
+    margin: 0 0 4px;
+    font-size: 20px;
+  }
+
+  label {
+    display: grid;
+    gap: 5px;
+    font-weight: 600;
+  }
+
+  input,
+  textarea {
+    width: 100%;
+    margin: 0;
+    box-sizing: border-box;
+    font: inherit;
+    font-weight: normal;
+  }
+
+  textarea {
+    min-height: 140px;
+    resize: vertical;
+  }
+
+  input[readonly] {
+    background-color: var(--color-background-dark);
+    color: var(--color-text-maxcontrast);
+    cursor: default;
+  }
+}
+
+.gestion-mail-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
 .menu-content {
   font-size:20px;
   margin-bottom: 10px;

--- a/src/css/mycss.less
+++ b/src/css/mycss.less
@@ -241,7 +241,11 @@ table.dataTable.display tbody tr.even > [class*="sorting_"] {
 }
 
 .gestion-mail-dialog {
+  position: fixed;
+  inset: 0;
   width: min(520px, calc(100vw - 32px));
+  max-height: calc(100vh - 32px);
+  margin: auto;
   padding: 0;
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius-large);

--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -243,13 +243,7 @@ function showMailConfirmation(email) {
 }
 
 function showMailSentConfirmation() {
-  const title = t("gestion", "Email sent");
-  const message = t("gestion", "The email was sent successfully.");
-  if (window.OC?.dialogs?.alert) {
-    window.OC.dialogs.alert(message, title);
-  } else {
-    window.alert(title + "\n\n" + message);
-  }
+  showMessage(t("gestion", "The email was sent successfully."));
 }
 
 function showMailPrerequisites() {

--- a/src/js/pdf.js
+++ b/src/js/pdf.js
@@ -143,15 +143,26 @@ async function sendDocumentByMail(detailUrl) {
     const element = sourceDocument.querySelector("#PDFcontent").cloneNode(true);
     element.querySelectorAll("[data-html2canvas-ignore]").forEach(node => node.remove());
 
+    const email = await showMailConfirmation({
+      from: status.account?.address || status.account?.label || "",
+      to: recipient,
+      subject: type + " " + pdfName,
+      body: t("gestion", "Hello,\n\nPlease find your document attached.\n\nKind regards.")
+    });
+
+    if (email === null) {
+      return;
+    }
+
     const response = await fetch(baseUrl + "/personal-mail/send", {
       method: "POST",
       headers: csrfHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify({
         html: element.outerHTML,
         name,
-        to: recipient,
-        subject: type + " " + pdfName,
-        body: t("gestion", "Hello,\n\nPlease find your document attached.\n\nKind regards.")
+        to: email.to,
+        subject: email.subject,
+        body: email.body
       })
     });
 
@@ -159,8 +170,86 @@ async function sendDocumentByMail(detailUrl) {
     if (!response.ok) {
       throw new Error(result.message || t("gestion", "Email sending failed."));
     }
-    showMessage(t("gestion", "Email sent"));
+    showMailSentConfirmation();
   });
+}
+
+function showMailConfirmation(email) {
+  return new Promise(resolve => {
+    const dialog = document.createElement("dialog");
+    dialog.className = "gestion-mail-dialog";
+
+    const form = document.createElement("form");
+    form.method = "dialog";
+    form.className = "gestion-mail-dialog-form";
+
+    const title = document.createElement("h2");
+    title.textContent = t("gestion", "Send document by email");
+    form.appendChild(title);
+
+    const createField = (labelText, value, readOnly, multiline = false) => {
+      const label = document.createElement("label");
+      label.textContent = labelText;
+      const field = multiline ? document.createElement("textarea") : document.createElement("input");
+      field.value = value;
+      field.readOnly = readOnly;
+      field.required = true;
+      if (multiline) field.rows = 8;
+      label.appendChild(field);
+      form.appendChild(label);
+      return field;
+    };
+
+    createField(t("gestion", "Sender email"), email.from, true);
+    const recipient = createField(t("gestion", "Recipient email"), email.to, true);
+    const subject = createField(t("gestion", "Subject"), email.subject, false);
+    const body = createField(t("gestion", "Message"), email.body, false, true);
+
+    const actions = document.createElement("div");
+    actions.className = "gestion-mail-dialog-actions";
+    const cancel = document.createElement("button");
+    cancel.type = "button";
+    cancel.textContent = t("gestion", "Cancel");
+    const send = document.createElement("button");
+    send.type = "submit";
+    send.className = "primary";
+    send.textContent = t("gestion", "Send");
+    actions.append(cancel, send);
+    form.appendChild(actions);
+    dialog.appendChild(form);
+    document.body.appendChild(dialog);
+
+    let submitted = false;
+    cancel.addEventListener("click", () => dialog.close());
+    form.addEventListener("submit", event => {
+      event.preventDefault();
+      if (!form.reportValidity()) return;
+      submitted = true;
+      dialog.close();
+    });
+    dialog.addEventListener("close", () => {
+      const result = submitted ? {
+        to: recipient.value,
+        subject: subject.value.trim(),
+        body: body.value
+      } : null;
+      dialog.remove();
+      resolve(result);
+    }, { once: true });
+
+    dialog.showModal();
+    subject.focus();
+  });
+}
+
+function showMailSentConfirmation() {
+  const title = t("gestion", "Email sent");
+  const message = t("gestion", "The email was sent successfully.");
+  if (window.OC?.dialogs?.alert) {
+    window.OC.dialogs.alert(message, title);
+  } else {
+    window.alert(title + "\n\n" + message);
+  }
 }
 
 function showMailPrerequisites() {


### PR DESCRIPTION
## Résumé

- affiche une modale avant l’envoi d’un devis ou d’une facture
- présente l’adresse d’expédition et l’adresse du client en lecture seule
- permet de modifier le sujet et le corps du message
- ajoute les actions Annuler et Envoyer
- affiche une confirmation distincte uniquement après un envoi accepté par le serveur
- conserve les erreurs d’envoi dans le flux d’erreur existant

## Validation

- npm run build (réussi, avertissements de taille préexistants)
- composer validate --no-check-publish
- npm audit --offline : aucune vulnérabilité
- git diff --check

Les autres modifications locales présentes dans le dépôt ont été laissées hors du commit.