### PR TITLE
Import customers from Nextcloud Contacts

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -18,6 +18,8 @@ return [
         ['name' => 'crud#update', 'url' => '/update', 'verb' => 'POST'],
         ['name' => 'configuration#updateConfiguration', 'url' => '/updateConfiguration', 'verb' => 'POST'],
         ['name' => 'client#insertClient', 'url' => '/client/insert', 'verb' => 'POST'],
+        ['name' => 'client#contacts', 'url' => '/client/contacts', 'verb' => 'GET'],
+        ['name' => 'client#importContact', 'url' => '/client/import-contact', 'verb' => 'POST'],
 
         ['name' => 'devis#getDevis', 'url' => '/getDevis', 'verb' => 'PROPFIND'],
         ['name' => 'devis#devisshow', 'url' => '/devis/{numdevis}/show', 'verb' => 'GET'],

--- a/lib/Controller/ClientController.php
+++ b/lib/Controller/ClientController.php
@@ -2,6 +2,8 @@
 namespace OCA\Gestion\Controller;
 
 use OCA\Gestion\Service\DataService;
+use OCA\Gestion\Service\ContactImportService;
+use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\UseSession;
 use OCP\IRequest;
@@ -9,9 +11,28 @@ use OCP\IRequest;
 class ClientController extends Controller {
 	private DataService $dataService;
 
-	public function __construct($AppName, IRequest $request, DataService $dataService) {
+	public function __construct($AppName, IRequest $request, DataService $dataService, ContactImportService $contactImportService) {
 		parent::__construct($AppName, $request);
 		$this->dataService = $dataService;
+		$this->contactImportService = $contactImportService;
+	}
+	private ContactImportService $contactImportService;
+
+	/** @NoAdminRequired */
+	#[UseSession]
+	public function contacts(): DataResponse {
+		return new DataResponse($this->contactImportService->list());
+	}
+
+	/** @NoAdminRequired */
+	#[UseSession]
+	public function importContact(string $id): DataResponse {
+		$contact = $this->contactImportService->find($id);
+		if ($contact === null) {
+			return new DataResponse(['message' => 'Contact not found.'], 404);
+		}
+		$this->dataService->insertContactClient($contact);
+		return new DataResponse(['status' => 'success']);
 	}
 
 	/**

--- a/lib/Db/Bdd.php
+++ b/lib/Db/Bdd.php
@@ -125,19 +125,19 @@ class Bdd {
         return $trace[2]['function'];
     }
 
-    public function insertClient($idNextcloud){
+    public function insertClient($idNextcloud, array $client = []){
         $sql = "INSERT INTO ".$this->tableprefix."client (id_configuration,nom,prenom,legal_one,entreprise,telephone,mail,adresse,zip_code,city_name,country_code,company_identification,vat_number) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)";
         $this->execSQLNoData($sql,array($idNextcloud,
-                                            $this->l->t('Last name'),
-                                            $this->l->t('First name'),
+                                            $client['nom'] ?? $this->l->t('Last name'),
+                                            $client['prenom'] ?? $this->l->t('First name'),
                                             $this->l->t('Limited company'),
-                                            $this->l->t('Company'),
-                                            $this->l->t('Phone number'),
-                                            $this->l->t('Email'),
-                                            $this->l->t('Address'),
-                                            $this->l->t('zip_code'),
-                                            $this->l->t('city_name'),
-                                            'FR',
+                                            $client['entreprise'] ?? $this->l->t('Company'),
+                                            $client['telephone'] ?? $this->l->t('Phone number'),
+                                            $client['mail'] ?? $this->l->t('Email'),
+                                            $client['adresse'] ?? $this->l->t('Address'),
+                                            $client['zip_code'] ?? $this->l->t('zip_code'),
+                                            $client['city_name'] ?? $this->l->t('city_name'),
+                                            $client['country_code'] ?? 'FR',
                                             '',
                                             ''
                                         )

--- a/lib/Service/ContactImportService.php
+++ b/lib/Service/ContactImportService.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Gestion\Service;
+
+use OCP\Contacts\IManager;
+
+class ContactImportService {
+	private const PROPERTIES = ['FN', 'N', 'ORG', 'EMAIL', 'TEL', 'ADR'];
+
+	public function __construct(private IManager $contacts) {
+	}
+
+	public function list(): array {
+		if (!$this->contacts->isEnabled()) {
+			return [];
+		}
+
+		return array_values(array_map(
+			fn (array $contact): array => $this->normalize($contact),
+			$this->contacts->search('', self::PROPERTIES, ['types' => true, 'limit' => 500])
+		));
+	}
+
+	public function find(string $id): ?array {
+		foreach ($this->list() as $contact) {
+			if ((string)$contact['id'] === $id) {
+				return $contact;
+			}
+		}
+		return null;
+	}
+
+	private function normalize(array $contact): array {
+		$name = $this->values($contact['N'] ?? []);
+		$address = $this->firstPropertyValue($contact['ADR'] ?? []);
+		$addressParts = is_array($address) ? $address : explode(';', (string)$address);
+		$country = strtoupper((string)($addressParts[6] ?? ''));
+
+		return [
+			'id' => (string)($contact['id'] ?? ''),
+			'displayName' => (string)($contact['FN'] ?? trim(($name[1] ?? '') . ' ' . ($name[0] ?? ''))),
+			'nom' => (string)($name[0] ?? ''),
+			'prenom' => (string)($name[1] ?? ''),
+			'entreprise' => implode(' ', $this->values($contact['ORG'] ?? [])),
+			'telephone' => (string)$this->first($contact['TEL'] ?? ''),
+			'mail' => (string)$this->first($contact['EMAIL'] ?? ''),
+			'adresse' => trim(implode(' ', array_filter([$addressParts[1] ?? '', $addressParts[2] ?? '']))),
+			'zip_code' => (string)($addressParts[5] ?? ''),
+			'city_name' => (string)($addressParts[3] ?? ''),
+			'country_code' => strlen($country) === 2 ? $country : '',
+		];
+	}
+
+	private function first(mixed $value): mixed {
+		$values = $this->values($value);
+		return $values[0] ?? '';
+	}
+
+	private function firstPropertyValue(mixed $value): mixed {
+		if (!is_array($value)) {
+			return $value;
+		}
+		if (array_key_exists('value', $value)) {
+			return $value['value'];
+		}
+		$first = reset($value);
+		return is_array($first) && array_key_exists('value', $first) ? $first['value'] : $first;
+	}
+
+	private function values(mixed $value): array {
+		if (!is_array($value)) {
+			return $value === null || $value === '' ? [] : [$value];
+		}
+		if (array_key_exists('value', $value)) {
+			return is_array($value['value']) ? $value['value'] : [$value['value']];
+		}
+
+		$result = [];
+		foreach ($value as $item) {
+			foreach ($this->values($item) as $entry) {
+				$result[] = $entry;
+			}
+		}
+		return $result;
+	}
+}

--- a/lib/Service/DataService.php
+++ b/lib/Service/DataService.php
@@ -65,6 +65,10 @@ class DataService {
 		return $this->myDb->insertClient($this->currentCompany());
 	}
 
+	public function insertContactClient(array $client) {
+		return $this->myDb->insertClient($this->currentCompany(), $client);
+	}
+
 	public function insertDevis() {
 		return $this->myDb->insertDevis($this->currentCompany());
 	}

--- a/src/css/mycss.less
+++ b/src/css/mycss.less
@@ -245,3 +245,35 @@ table.dataTable.display tbody tr.even > [class*="sorting_"] {
   margin-bottom: 10px;
   margin-left: 25px;
 }
+
+.gestion-contact-dialog {
+  position: fixed;
+  inset: 0;
+  width: min(560px, calc(100vw - 32px));
+  max-height: calc(100vh - 32px);
+  margin: auto;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-large);
+  background: var(--color-main-background);
+  color: var(--color-main-text);
+  box-shadow: 0 8px 30px rgb(0 0 0 / 28%);
+
+  &::backdrop { background: rgb(0 0 0 / 45%); }
+
+  form {
+    display: grid;
+    gap: 14px;
+    padding: 20px;
+  }
+
+  h2 { margin: 0; }
+  input, select { width: 100%; box-sizing: border-box; }
+  select { min-height: 220px; }
+}
+
+.gestion-contact-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/src/js/client.js
+++ b/src/js/client.js
@@ -6,8 +6,84 @@ import "./listener/main_listener";
 import DataTable from "datatables.net";
 import { globalConfiguration, optionDatatable } from "./modules/mainFunction.js";
 import { Client } from "./objects/client.js";
+import { baseUrl } from "./modules/mainFunction.js";
+import { csrfHeaders } from "./modules/csrf.js";
+import { showError, showSuccess } from "@nextcloud/dialogs";
 
 document.addEventListener("DOMContentLoaded", function () {
     globalConfiguration();
-    Client.loadClientDT(new DataTable(".tabledt",optionDatatable));
+    const clientTable = new DataTable(".tabledt",optionDatatable);
+    Client.loadClientDT(clientTable);
+    document.getElementById("importContact")?.addEventListener("click", () => openContactImport(clientTable));
 });
+
+async function openContactImport(clientTable) {
+    try {
+        const response = await fetch(baseUrl + "/client/contacts", { headers: csrfHeaders() });
+        if (!response.ok) throw new Error(t("gestion", "Unable to load Nextcloud contacts."));
+        const contacts = await response.json();
+        if (contacts.length === 0) throw new Error(t("gestion", "No Nextcloud contact is available."));
+
+        const dialog = document.createElement("dialog");
+        dialog.className = "gestion-contact-dialog";
+        const form = document.createElement("form");
+        form.method = "dialog";
+        const title = document.createElement("h2");
+        title.textContent = t("gestion", "Import a Nextcloud contact");
+        const search = document.createElement("input");
+        search.type = "search";
+        search.placeholder = t("gestion", "Search contacts");
+        const select = document.createElement("select");
+        select.size = Math.min(10, contacts.length);
+        const render = pattern => {
+            select.replaceChildren();
+            contacts.filter(contact => JSON.stringify(contact).toLowerCase().includes(pattern.toLowerCase())).forEach(contact => {
+                const option = document.createElement("option");
+                option.value = contact.id;
+                option.textContent = [contact.displayName, contact.entreprise, contact.mail].filter(Boolean).join(" — ");
+                select.appendChild(option);
+            });
+            if (select.options.length) select.selectedIndex = 0;
+        };
+        render("");
+        search.addEventListener("input", () => render(search.value));
+        const actions = document.createElement("div");
+        actions.className = "gestion-contact-dialog-actions";
+        const cancel = document.createElement("button");
+        cancel.type = "button";
+        cancel.textContent = t("gestion", "Cancel");
+        const submit = document.createElement("button");
+        submit.type = "submit";
+        submit.className = "primary";
+        submit.textContent = t("gestion", "Import customer");
+        actions.append(cancel, submit);
+        form.append(title, search, select, actions);
+        dialog.appendChild(form);
+        document.body.appendChild(dialog);
+        cancel.addEventListener("click", () => dialog.close());
+        dialog.addEventListener("close", () => dialog.remove(), { once: true });
+        form.addEventListener("submit", async event => {
+            event.preventDefault();
+            if (!select.value) return;
+            submit.disabled = true;
+            try {
+                const importResponse = await fetch(baseUrl + "/client/import-contact", {
+                    method: "POST",
+                    headers: csrfHeaders({ "Content-Type": "application/json" }),
+                    body: JSON.stringify({ id: select.value })
+                });
+                if (!importResponse.ok) throw new Error(t("gestion", "Unable to import this contact."));
+                dialog.close();
+                Client.loadClientDT(clientTable);
+                showSuccess(t("gestion", "Contact imported as a customer."));
+            } catch (error) {
+                submit.disabled = false;
+                showError(error.message);
+            }
+        });
+        dialog.showModal();
+        search.focus();
+    } catch (error) {
+        showError(error.message);
+    }
+}

--- a/templates/content/index.php
+++ b/templates/content/index.php
@@ -5,6 +5,7 @@
         <span><?php p($l->t('Customer'));?></span>
         <span class="material-symbols-outlined">chevron_right</span>
         <button style="margin-left:3px;" type="button"  id="newClient"><?php p($l->t('Add customer'));?></button>
+        <button style="margin-left:3px;" type="button" id="importContact"><span class="material-symbols">person_add</span> <?php p($l->t('Import from Contacts'));?></button>
     </div>
     <table id="client" class="display tabledt" style="font-size:11px;">
         <thead>


### PR DESCRIPTION
## Résumé

- ajoute un bouton Importer depuis Contacts dans la liste des clients
- utilise l’API publique Contacts de Nextcloud et uniquement les carnets accessibles à l’utilisateur connecté
- propose une modale centrée avec recherche et sélection du contact
- importe le nom, le prénom, la société, l’email, le téléphone et les différentes parties de l’adresse lorsqu’elles existent
- conserve les champs absents vides et n’importe le pays que s’il est fourni sous forme de code ISO à deux lettres
- recharge automatiquement la liste des clients et affiche une confirmation après création

## Validation

- syntaxe PHP validée sur tous les fichiers modifiés
- npm run build réussi (avertissements de taille préexistants)
- composer validate --no-check-publish
- git diff --check

Les autres modifications locales déjà présentes ont été laissées hors du commit.