### PR TITLE
Fix contact import and add compact product header toggle

### DIFF
--- a/lib/Controller/ClientController.php
+++ b/lib/Controller/ClientController.php
@@ -26,11 +26,7 @@ class ClientController extends Controller {
 
 	/** @NoAdminRequired */
 	#[UseSession]
-	public function importContact(string $id): DataResponse {
-		$contact = $this->contactImportService->find($id);
-		if ($contact === null) {
-			return new DataResponse(['message' => 'Contact not found.'], 404);
-		}
+	public function importContact(array $contact): DataResponse {
 		$this->dataService->insertContactClient($contact);
 		return new DataResponse(['status' => 'success']);
 	}

--- a/lib/Service/DataService.php
+++ b/lib/Service/DataService.php
@@ -66,7 +66,13 @@ class DataService {
 	}
 
 	public function insertContactClient(array $client) {
-		return $this->myDb->insertClient($this->currentCompany(), $client);
+		$fields = ['nom', 'prenom', 'entreprise', 'telephone', 'mail', 'adresse', 'zip_code', 'city_name', 'country_code'];
+		$normalized = [];
+		foreach ($fields as $field) {
+			$value = $client[$field] ?? '';
+			$normalized[$field] = is_scalar($value) ? mb_substr(trim((string)$value), 0, 500) : '';
+		}
+		return $this->myDb->insertClient($this->currentCompany(), $normalized);
 	}
 
 	public function insertDevis() {

--- a/src/css/mycss.less
+++ b/src/css/mycss.less
@@ -118,6 +118,54 @@ table.dataTable.display tbody tr.even > [class*="sorting_"] {
   }
 }
 
+.product-header-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 36px;
+  min-width: 36px;
+  height: 20px;
+  min-height: 20px;
+  margin: 0 !important;
+  padding: 2px !important;
+  border: 1px solid var(--color-border-maxcontrast) !important;
+  border-radius: 10px !important;
+  box-sizing: border-box;
+  background: var(--color-background-dark) !important;
+  cursor: pointer;
+  transition: background-color 120ms ease;
+
+  .product-header-toggle-knob {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--color-main-background);
+    box-shadow: 0 1px 2px rgb(0 0 0 / 30%);
+    transform: translateX(0);
+    transition: transform 120ms ease;
+  }
+
+  .material-symbols {
+    display: none;
+    font-size: 12px;
+    color: var(--color-primary-element);
+  }
+
+  &.active {
+    border-color: var(--color-success) !important;
+    background: var(--color-success) !important;
+
+    .product-header-toggle-knob { transform: translateX(16px); }
+    .material-symbols { display: inline-block; }
+  }
+
+  &:focus-visible { outline: 2px solid var(--color-primary-element); }
+  &:disabled { cursor: wait; opacity: .65; }
+}
+
 .gestion-version {
   padding: 12px;
   color: #5f6368;

--- a/src/css/mycss.less
+++ b/src/css/mycss.less
@@ -118,18 +118,20 @@ table.dataTable.display tbody tr.even > [class*="sorting_"] {
   }
 }
 
-.product-header-toggle {
+button.product-header-toggle {
   position: relative;
   display: inline-flex;
   align-items: center;
-  width: 36px;
-  min-width: 36px;
-  height: 20px;
-  min-height: 20px;
+  width: 30px;
+  min-width: 30px;
+  max-width: 30px;
+  height: 16px;
+  min-height: 16px;
+  max-height: 16px;
   margin: 0 !important;
   padding: 2px !important;
   border: 1px solid var(--color-border-maxcontrast) !important;
-  border-radius: 10px !important;
+  border-radius: 8px !important;
   box-sizing: border-box;
   background: var(--color-background-dark) !important;
   cursor: pointer;
@@ -139,8 +141,8 @@ table.dataTable.display tbody tr.even > [class*="sorting_"] {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 14px;
-    height: 14px;
+    width: 10px;
+    height: 10px;
     border-radius: 50%;
     background: var(--color-main-background);
     box-shadow: 0 1px 2px rgb(0 0 0 / 30%);
@@ -150,7 +152,7 @@ table.dataTable.display tbody tr.even > [class*="sorting_"] {
 
   .material-symbols {
     display: none;
-    font-size: 12px;
+    font-size: 9px;
     color: var(--color-primary-element);
   }
 
@@ -158,7 +160,7 @@ table.dataTable.display tbody tr.even > [class*="sorting_"] {
     border-color: var(--color-success) !important;
     background: var(--color-success) !important;
 
-    .product-header-toggle-knob { transform: translateX(16px); }
+    .product-header-toggle-knob { transform: translateX(14px); }
     .material-symbols { display: inline-block; }
   }
 

--- a/src/css/mycss.less
+++ b/src/css/mycss.less
@@ -378,8 +378,37 @@ table.dataTable.display tbody tr.even > [class*="sorting_"] {
   }
 
   h2 { margin: 0; }
-  input, select { width: 100%; box-sizing: border-box; }
-  select { min-height: 220px; }
+  input { width: 100%; box-sizing: border-box; }
+}
+
+.gestion-contact-list {
+  display: grid;
+  align-content: start;
+  min-height: 220px;
+  max-height: 320px;
+  padding: 4px;
+  overflow-y: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-element);
+  background: var(--color-main-background);
+}
+
+.gestion-contact-list-item {
+  width: 100%;
+  min-height: 34px;
+  margin: 0 !important;
+  padding: 6px 8px !important;
+  border: 0 !important;
+  border-radius: var(--border-radius-element);
+  background: transparent !important;
+  color: var(--color-main-text) !important;
+  text-align: left;
+
+  &:hover { background: var(--color-background-hover) !important; }
+  &.active {
+    background: var(--color-primary-element) !important;
+    color: var(--color-primary-element-text) !important;
+  }
 }
 
 .gestion-contact-dialog-actions {

--- a/src/js/client.js
+++ b/src/js/client.js
@@ -32,17 +32,29 @@ async function openContactImport(clientTable) {
         const search = document.createElement("input");
         search.type = "search";
         search.placeholder = t("gestion", "Search contacts");
-        const select = document.createElement("select");
-        select.size = Math.min(10, contacts.length);
+        const list = document.createElement("div");
+        list.className = "gestion-contact-list";
+        let selectedContact = null;
         const render = pattern => {
-            select.replaceChildren();
+            list.replaceChildren();
+            selectedContact = null;
             contacts.filter(contact => JSON.stringify(contact).toLowerCase().includes(pattern.toLowerCase())).forEach(contact => {
-                const option = document.createElement("option");
-                option.value = contact.id;
-                option.textContent = [contact.displayName, contact.entreprise, contact.mail].filter(Boolean).join(" — ");
-                select.appendChild(option);
+                const item = document.createElement("button");
+                item.type = "button";
+                item.className = "gestion-contact-list-item";
+                item.textContent = [contact.displayName, contact.entreprise, contact.mail].filter(Boolean).join(" — ");
+                item.addEventListener("click", () => {
+                    list.querySelector(".active")?.classList.remove("active");
+                    item.classList.add("active");
+                    selectedContact = contact;
+                });
+                item.addEventListener("dblclick", () => {
+                    selectedContact = contact;
+                    importSelectedContact();
+                });
+                list.appendChild(item);
             });
-            if (select.options.length) select.selectedIndex = 0;
+            list.firstElementChild?.click();
         };
         render("");
         search.addEventListener("input", () => render(search.value));
@@ -56,20 +68,23 @@ async function openContactImport(clientTable) {
         submit.className = "primary";
         submit.textContent = t("gestion", "Import customer");
         actions.append(cancel, submit);
-        form.append(title, search, select, actions);
+        form.append(title, search, list, actions);
         dialog.appendChild(form);
         document.body.appendChild(dialog);
         cancel.addEventListener("click", () => dialog.close());
         dialog.addEventListener("close", () => dialog.remove(), { once: true });
         const importSelectedContact = async () => {
-            if (!select.value) return;
+            if (!selectedContact) {
+                showError(t("gestion", "Select a contact to import."));
+                return;
+            }
             submit.disabled = true;
             submit.textContent = t("gestion", "Importing…");
             try {
                 const importResponse = await fetch(baseUrl + "/client/import-contact", {
                     method: "POST",
                     headers: csrfHeaders({ "Content-Type": "application/json" }),
-                    body: JSON.stringify({ id: select.value })
+                    body: JSON.stringify({ contact: selectedContact })
                 });
                 if (!importResponse.ok) {
                     const result = await importResponse.json().catch(() => ({}));
@@ -85,7 +100,6 @@ async function openContactImport(clientTable) {
             }
         };
         submit.addEventListener("click", importSelectedContact);
-        select.addEventListener("dblclick", importSelectedContact);
         dialog.showModal();
         search.focus();
     } catch (error) {

--- a/src/js/client.js
+++ b/src/js/client.js
@@ -27,7 +27,6 @@ async function openContactImport(clientTable) {
         const dialog = document.createElement("dialog");
         dialog.className = "gestion-contact-dialog";
         const form = document.createElement("form");
-        form.method = "dialog";
         const title = document.createElement("h2");
         title.textContent = t("gestion", "Import a Nextcloud contact");
         const search = document.createElement("input");
@@ -53,7 +52,7 @@ async function openContactImport(clientTable) {
         cancel.type = "button";
         cancel.textContent = t("gestion", "Cancel");
         const submit = document.createElement("button");
-        submit.type = "submit";
+        submit.type = "button";
         submit.className = "primary";
         submit.textContent = t("gestion", "Import customer");
         actions.append(cancel, submit);
@@ -62,25 +61,31 @@ async function openContactImport(clientTable) {
         document.body.appendChild(dialog);
         cancel.addEventListener("click", () => dialog.close());
         dialog.addEventListener("close", () => dialog.remove(), { once: true });
-        form.addEventListener("submit", async event => {
-            event.preventDefault();
+        const importSelectedContact = async () => {
             if (!select.value) return;
             submit.disabled = true;
+            submit.textContent = t("gestion", "Importing…");
             try {
                 const importResponse = await fetch(baseUrl + "/client/import-contact", {
                     method: "POST",
                     headers: csrfHeaders({ "Content-Type": "application/json" }),
                     body: JSON.stringify({ id: select.value })
                 });
-                if (!importResponse.ok) throw new Error(t("gestion", "Unable to import this contact."));
+                if (!importResponse.ok) {
+                    const result = await importResponse.json().catch(() => ({}));
+                    throw new Error(result.message || t("gestion", "Unable to import this contact."));
+                }
                 dialog.close();
                 Client.loadClientDT(clientTable);
                 showSuccess(t("gestion", "Contact imported as a customer."));
             } catch (error) {
                 submit.disabled = false;
+                submit.textContent = t("gestion", "Import customer");
                 showError(error.message);
             }
-        });
+        };
+        submit.addEventListener("click", importSelectedContact);
+        select.addEventListener("dblclick", importSelectedContact);
         dialog.showModal();
         search.focus();
     } catch (error) {

--- a/src/js/objects/produit.js
+++ b/src/js/objects/produit.js
@@ -40,13 +40,14 @@ export class Produit {
       '<option value="' + value + '"' + (value === this.vat_category ? ' selected' : '') + '>' + label + '</option>'
     ).join('');
     const exemptionReasonButtonHidden = this.vat_category === 'E' ? '' : ' hidden';
+    const isHeader = String(this.header) === '1';
     let myrow = [
       '<div class="editable" data-table="produit" data-column="reference" data-id="' + this.id + '">' + this.reference + '</div>',
       '<div class="editable" data-table="produit" data-column="description" data-id="' + this.id + '">' + this.description + '</div>',
       '<div class="editableNumeric" data-table="produit" data-column="prix_unitaire" data-id="' + this.id + '">' + cur.format(this.prix_unitaire) + '</div>',
       '<div class="editable" data-table="produit" data-column="vat" data-id="' + this.id + '">' + this.vat + '%</div>',
       '<select class="editableSelect vat-category-select" data-table="produit" data-column="vat_category" data-id="' + this.id + '" data-current="' + this.vat_category + '" aria-label="' + t('gestion', 'Electronic invoice VAT category') + '">' + vatCategoryOptions + '</select>',
-      '<div class="editable" data-table="produit" data-column="header" data-id="' + this.id + '">' + this.header + '</div>',
+      '<button type="button" class="product-header-toggle' + (isHeader ? ' active' : '') + '" data-id="' + this.id + '" data-value="' + (isHeader ? '1' : '0') + '" aria-pressed="' + (isHeader ? 'true' : 'false') + '" aria-label="' + t('gestion', 'Use as a header row') + '"><span class="product-header-toggle-knob"><span class="material-symbols">check</span></span></button>',
       '<button type="button" class="vat-exemption-reason-action" data-id="' + this.id + '" data-reason-code="' + this.vat_exemption_reason_code + '" title="' + t('gestion', 'VAT exemption reason') + '" aria-label="' + t('gestion', 'VAT exemption reason') + '"' + exemptionReasonButtonHidden + '><span class="material-symbols-outlined">gavel</span></button>'
         + '<div data-modifier="produit" data-id=' + this.id + ' data-table="produit" style="display:inline-block;margin-right:0px;" class="deleteItem icon-delete"></div>',
     ];

--- a/src/js/produit.js
+++ b/src/js/produit.js
@@ -6,9 +6,27 @@ import DataTable from "datatables.net";
 import { globalConfiguration, optionDatatable } from "./modules/mainFunction.js";
 import "./listener/main_listener";
 import { Produit } from "./objects/produit.js";
+import { updateDB } from "./modules/ajaxRequest.js";
 
 window.addEventListener("DOMContentLoaded", function () {
     globalConfiguration();
 
     Produit.loadProduitDT(new DataTable(".tabledt",optionDatatable));
+
+    document.addEventListener("click", async event => {
+        const toggle = event.target.closest(".product-header-toggle");
+        if (!toggle || toggle.disabled) return;
+
+        const previousValue = toggle.dataset.value;
+        const nextValue = previousValue === "1" ? "0" : "1";
+        toggle.disabled = true;
+
+        const saved = await updateDB("produit", "header", nextValue, toggle.dataset.id);
+        if (saved) {
+            toggle.dataset.value = nextValue;
+            toggle.classList.toggle("active", nextValue === "1");
+            toggle.setAttribute("aria-pressed", nextValue === "1" ? "true" : "false");
+        }
+        toggle.disabled = false;
+    });
 });


### PR DESCRIPTION
## Résumé

- remplace la valeur 0/1 de la colonne En-tête par un interrupteur compact gris/vert avec coche
- réduit explicitement l’interrupteur à 30 × 16 px malgré les styles globaux Nextcloud
- enregistre immédiatement l’état en base et bloque le contrôle pendant la requête
- embarque les correctifs restés après la fusion de la PR #600
- déclenche explicitement l’import Contacts au clic ou au double-clic
- remplace la liste native avec flèches parasites par une liste de contacts cliquable
- importe la fiche normalisée sans dépendre d’un identifiant Contacts interne éventuellement vide
- affiche l’état d’import et les erreurs retournées par le serveur

## Validation

- npm run build réussi (avertissements de taille préexistants)
- syntaxe PHP valide pour les services et contrôleurs Contacts
- composer validate --no-check-publish
- npm audit --offline : aucune vulnérabilité
- git diff --check sur les fichiers concernés

Les autres modifications locales ont été laissées hors des commits.