### PR TITLE
Add Nextcloud compatibility CI, update README, and replace deprecated DB iterator with fetchAll

### DIFF
--- a/.github/workflows/nextcloud-compatibility.yml
+++ b/.github/workflows/nextcloud-compatibility.yml
@@ -1,0 +1,98 @@
+name: Nextcloud compatibility
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nextcloud-compatibility-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  php-tests:
+    name: Nextcloud ${{ matrix.nextcloud }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        nextcloud: ['32', '33', '34', '35']
+
+    services:
+      database:
+        image: mariadb:11
+        env:
+          MARIADB_DATABASE: nextcloud
+          MARIADB_USER: nextcloud
+          MARIADB_PASSWORD: nextcloud
+          MARIADB_ROOT_PASSWORD: nextcloud
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@cf4cade2721270509d5b1c766ab3549210a39a2a # v2.33.0
+        with:
+          php-version: '8.3'
+          extensions: curl, gd, intl, mbstring, pdo_mysql, zip
+          coverage: none
+
+      - name: Download Nextcloud ${{ matrix.nextcloud }}
+        run: |
+          release_url="https://download.nextcloud.com/server/releases/latest-${{ matrix.nextcloud }}.zip"
+          if ! curl --fail --location --retry 3 --output nextcloud.zip "$release_url"; then
+            # Nextcloud 35 is declared compatible before its final release. Use
+            # its official beta until the latest-35 archive becomes available.
+            test '${{ matrix.nextcloud }}' = '35'
+            curl --fail --location --retry 3 \
+              --output nextcloud.zip \
+              'https://download.nextcloud.com/server/prereleases/nextcloud-35.0.0beta1.zip'
+          fi
+          unzip -q nextcloud.zip
+
+      - name: Checkout Gestion
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          path: nextcloud/apps/gestion
+
+      - name: Install Gestion dependencies
+        working-directory: nextcloud/apps/gestion
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Install Nextcloud and enable Gestion
+        working-directory: nextcloud
+        run: |
+          php occ maintenance:install \
+            --database=mysql \
+            --database-host=127.0.0.1 \
+            --database-name=nextcloud \
+            --database-user=nextcloud \
+            --database-pass=nextcloud \
+            --admin-user=admin \
+            --admin-pass=admin
+          php occ app:enable gestion
+          php occ app:list --enabled | grep -F -- '- gestion:'
+
+      - name: Run PHP unit and database tests
+        working-directory: nextcloud/apps/gestion
+        run: vendor/bin/phpunit --colors=always --testdox tests/Unit/Controller tests/Unit/Bdd tests/Unit/Service
+
+      - name: Check Nextcloud logs
+        if: always()
+        working-directory: nextcloud
+        run: |
+          if [ -f data/nextcloud.log ]; then
+            cat data/nextcloud.log
+            ! grep -F 'Call to undefined method OC\DB\ResultAdapter::iterateAssociative()' data/nextcloud.log
+          fi

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Translations are maintained with help from the Transifex team. Thank you to ever
 According to the app metadata, Gestion targets:
 
 - PHP 8 or newer;
-- Nextcloud 31 to 34;
+- Nextcloud 32 to 35;
 - a Nextcloud-compatible database, such as MariaDB/MySQL or PostgreSQL.
 
 The main dependencies are managed with Composer for PHP and npm/Webpack for JavaScript and CSS assets.
@@ -220,6 +220,12 @@ After installing dependencies:
 ```bash
 vendor/bin/phpunit --colors=always --testdox
 ```
+
+Pull requests targeting `master` automatically run the Controller, Bdd, and
+Service test suites against every supported Nextcloud major version (32 to 35)
+with MariaDB. The same compatibility workflow can also be started manually from
+the GitHub Actions page. Until Nextcloud 35 has a final release, the workflow
+uses its official beta archive as a compatibility target.
 
 UI tests may require Firefox, GeckoDriver, and a properly initialized Nextcloud test instance. The `protocole_tests.sh` script documents a historical scenario for starting MariaDB/Nextcloud containers and loading test datasets.
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@ If you require adaptations to comply with your country's regulations, please ope
 [![Donate](https://img.shields.io/badge/Donate-Buy%20me%20a%20coffee-yellow.svg)](https://www.buymeacoffee.com/benjaminaimard)
 
 ]]></description>
-    <version>3.3.1</version>
+    <version>3.3.2</version>
     <licence>agpl</licence>
     <author mail="benjamin@cybercorp.fr" homepage="https://github.com/baimard">Benjamin AIMARD</author>
     <namespace>Gestion</namespace>

--- a/lib/Db/Bdd.php
+++ b/lib/Db/Bdd.php
@@ -667,14 +667,14 @@ class Bdd {
 
     private function execSQLNoJsonReturn($sql, $conditions){
         $result = $this->db->executeQuery($sql, $conditions);
-        $rows = iterator_to_array($result->iterateAssociative(), false);
+        $rows = $result->fetchAll();
         $result->closeCursor();
         return $rows;
     }
 
     private function fetchAll($query): array {
         $result = $query->executeQuery();
-        $rows = iterator_to_array($result->iterateAssociative(), false);
+        $rows = $result->fetchAll();
         $result->closeCursor();
         return $rows;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gestion",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gestion",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@nextcloud/browserslist-config": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestion",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Application pour gérer votre micro entreprise, client, facture, devis",
   "author": "Benjamin AIMARD",
   "contributors": [


### PR DESCRIPTION
### Motivation
- Ensure the app remains compatible with newer Nextcloud releases (32–35) and recent DB API changes by removing usage of a removed iterator method and adding automated compatibility checks.
- Document the compatibility and CI process in the repository `README.md` so contributors understand supported Nextcloud versions and the automated tests that run.

### Description
- Add a GitHub Actions workflow `/.github/workflows/nextcloud-compatibility.yml` that downloads Nextcloud majors 32–35 (using the 35 beta until a final release), installs an instance with MariaDB, enables the app, and runs PHPUnit suites for Controller, Bdd, and Service tests.
- Update `README.md` to list Nextcloud compatibility as `32 to 35` and to describe the new compatibility workflow and how it is triggered.
- Modify `lib/Db/Bdd.php` to replace `iterator_to_array($result->iterateAssociative(), false)` with `$result->fetchAll()` in `execSQLNoJsonReturn` and `fetchAll` to avoid calling the removed `iterateAssociative()` method and to use the modern fetch API.

### Testing
- No automated tests were executed as part of this change; the new CI workflow will run `vendor/bin/phpunit --colors=always --testdox tests/Unit/Controller tests/Unit/Bdd tests/Unit/Service` on pull requests and pushes to `master` to verify compatibility with Nextcloud majors 32–35.
- The workflow is configured to use MariaDB 11 and will fall back to the official Nextcloud 35 beta archive until a final release is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d44acccec8332a8ec13f215df2a08)