### PR TITLE
Add navigation toggle template, safely initialize toggle, make updateEditable async and bump version to 3.3.4

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@ If you require adaptations to comply with your country's regulations, please ope
 [![Donate](https://img.shields.io/badge/Donate-Buy%20me%20a%20coffee-yellow.svg)](https://www.buymeacoffee.com/benjaminaimard)
 
 ]]></description>
-    <version>3.3.3</version>
+    <version>3.3.4</version>
     <licence>agpl</licence>
     <author mail="benjamin@cybercorp.fr" homepage="https://github.com/baimard">Benjamin AIMARD</author>
     <namespace>Gestion</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gestion",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gestion",
-      "version": "3.3.3",
+      "version": "3.3.4",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@nextcloud/browserslist-config": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestion",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "Application pour gérer votre micro entreprise, client, facture, devis",
   "author": "Benjamin AIMARD",
   "contributors": [

--- a/src/js/modules/ajaxRequest.js
+++ b/src/js/modules/ajaxRequest.js
@@ -446,7 +446,7 @@ export function getAnnualTurnoverPerMonthNoVat(cur) {
  * 
  * @param {*} myCase 
  */
-export function updateEditable(myCase) {
+export async function updateEditable(myCase) {
 
     let value = myCase.innerText;
 
@@ -454,7 +454,7 @@ export function updateEditable(myCase) {
         value = value.replace('%', '');
     }
 
-    updateDB(
+    const saved = await updateDB(
         myCase.dataset.table,
         myCase.dataset.column,
         value,
@@ -462,6 +462,12 @@ export function updateEditable(myCase) {
     );
 
     myCase.removeAttribute('contenteditable');
+
+    if (saved && myCase.dataset.modifier === 'getProduitsById') {
+        await getProduitsById();
+    }
+
+    return saved;
 }
 
 /**

--- a/src/js/modules/navigation.js
+++ b/src/js/modules/navigation.js
@@ -13,19 +13,19 @@ export function initializeNavigationToggle() {
     const app = document.getElementById('app');
     const navigation = document.getElementById('app-navigation');
 
-    if (!app || !navigation || app.querySelector('.gestion-navigation-toggle')) {
+    if (!app || !navigation) {
         return;
     }
 
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'gestion-navigation-toggle';
-    button.setAttribute('aria-controls', 'app-navigation');
+    const button = app.querySelector('.gestion-navigation-toggle');
+    if (!button || button.dataset.navigationToggleInitialized === 'true') {
+        return;
+    }
+
+    button.dataset.navigationToggleInitialized = 'true';
     setNavigationState(app, button, true);
 
     button.addEventListener('click', () => {
         setNavigationState(app, button, app.classList.contains(NAVIGATION_CLOSED_CLASS));
     });
-
-    app.prepend(button);
 }

--- a/templates/configuration.php
+++ b/templates/configuration.php
@@ -4,6 +4,7 @@
 ?>
 
 <div id="app">
+	<?php print_unescaped($this->inc('navigation/toggle')); ?>
 	<div id="app-navigation">
 		<?php print_unescaped($this->inc('navigation/index')); ?>
 		<?php print_unescaped($this->inc('settings/index')); ?>

--- a/templates/devis.php
+++ b/templates/devis.php
@@ -4,6 +4,7 @@
 ?>
 
 <div id="app">
+	<?php print_unescaped($this->inc('navigation/toggle')); ?>
 	<div id="app-navigation">
 		<?php print_unescaped($this->inc('navigation/index')); ?>
 		<?php print_unescaped($this->inc('settings/index')); ?>
@@ -16,4 +17,3 @@
 		</div>
 	</div>
 </div>
-

--- a/templates/devisshow.php
+++ b/templates/devisshow.php
@@ -4,6 +4,7 @@
 ?>
 
 <div id="app">
+	<?php print_unescaped($this->inc('navigation/toggle')); ?>
 	<div id="app-navigation">
 		<?php print_unescaped($this->inc('navigation/index')); ?>
 		<?php print_unescaped($this->inc('settings/index')); ?>

--- a/templates/facture.php
+++ b/templates/facture.php
@@ -4,6 +4,7 @@
 ?>
 
 <div id="app">
+	<?php print_unescaped($this->inc('navigation/toggle')); ?>
 	<div id="app-navigation">
 		<?php print_unescaped($this->inc('navigation/index')); ?>
 		<?php print_unescaped($this->inc('settings/index')); ?>

--- a/templates/factureshow.php
+++ b/templates/factureshow.php
@@ -3,6 +3,7 @@
 	script('gestion', array('factureShow.app'));
 ?>
 <div id="app">
+	<?php print_unescaped($this->inc('navigation/toggle')); ?>
 	<div id="app-navigation">
 		<?php print_unescaped($this->inc('navigation/index')); ?>
 		<?php print_unescaped($this->inc('settings/index')); ?>

--- a/templates/index.php
+++ b/templates/index.php
@@ -4,6 +4,7 @@
 ?>
 
 <div id="app">
+	<?php print_unescaped($this->inc('navigation/toggle')); ?>
 	<div id="app-navigation">
 		<?php print_unescaped($this->inc('navigation/index')); ?>
 		<?php print_unescaped($this->inc('settings/index')); ?>

--- a/templates/legalnotice.php
+++ b/templates/legalnotice.php
@@ -4,6 +4,7 @@
 ?>
 
 <div id="app">
+	<?php print_unescaped($this->inc('navigation/toggle')); ?>
 	<div id="app-navigation">
 		<?php print_unescaped($this->inc('navigation/index')); ?>
 		<?php print_unescaped($this->inc('settings/index')); ?>
@@ -16,4 +17,3 @@
 		</div>
 	</div>
 </div>
-

--- a/templates/navigation/toggle.php
+++ b/templates/navigation/toggle.php
@@ -1,0 +1,8 @@
+<button
+	type="button"
+	class="gestion-navigation-toggle"
+	aria-controls="app-navigation"
+	aria-expanded="true"
+	aria-label="<?php p($l->t('Close navigation')); ?>"
+	title="<?php p($l->t('Close navigation')); ?>"
+></button>

--- a/templates/produit.php
+++ b/templates/produit.php
@@ -3,6 +3,7 @@
 	script('gestion', array('produit.app'));
 ?>
 <div id="app">
+	<?php print_unescaped($this->inc('navigation/toggle')); ?>
 	<div id="app-navigation">
 		<?php print_unescaped($this->inc('navigation/index')); ?>
 		<?php print_unescaped($this->inc('settings/index')); ?>

--- a/templates/statistique.php
+++ b/templates/statistique.php
@@ -4,6 +4,7 @@
 ?>
 
 <div id="app">
+	<?php print_unescaped($this->inc('navigation/toggle')); ?>
 	<div id="app-navigation">
 		<?php print_unescaped($this->inc('navigation/index')); ?>
 		<?php print_unescaped($this->inc('settings/index')); ?>
@@ -16,4 +17,3 @@
 		</div>
 	</div>
 </div>
-


### PR DESCRIPTION
### Motivation
- Provide a reusable DOM button for the app navigation toggle and avoid creating duplicate buttons in JavaScript. 
- Ensure inline edits are saved before subsequent actions and refresh product data when necessary. 
- Prepare a new release by bumping the package and app version to `3.3.4`.

### Description
- Bumped the package and app version from `3.3.3` to `3.3.4` in `appinfo/info.xml`, `package.json`, and `package-lock.json`.
- Added a new template `templates/navigation/toggle.php` that renders the navigation toggle button and included it at the top of multiple page templates (for example `index.php`, `devis.php`, `facture.php`, `produit.php`, `statistique.php`, `devisshow.php`, `factureshow.php`, `configuration.php`, `legalnotice.php`).
- Changed `initializeNavigationToggle` in `src/js/modules/navigation.js` to use an existing button (querying `.gestion-navigation-toggle`), guard against double initialization via a `data-navigation-toggle-initialized` flag, and stop creating/prepending the button from JS.
- Converted `updateEditable` in `src/js/modules/ajaxRequest.js` to an `async` function that `await`s the result of `updateDB`, removes the `contenteditable` attribute, conditionally calls `getProduitsById()` when the saved row has `data-modifier="getProduitsById"`, and returns the save result.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ee455958c833287042ecf4b1c2f72)